### PR TITLE
hexdrive.py function to report version - used by main app, EEPROM erase.

### DIFF
--- a/hexdrive.py
+++ b/hexdrive.py
@@ -10,8 +10,8 @@ from system.scheduler.events import RequestStopAppEvent
 
 import app
 
-# HexDrive.py App Version - parsed by app.py to check if upgrade is required
-APP_VERSION = 2647 
+# HexDrive.py App Version - used to check if upgrade is required
+APP_VERSION = 3 
 
 _ENABLE_PIN = 0	  # First LS pin used to enable the SMPSU
 _DETECT_PIN = 1   # Second LS pin used to sense if the SMPSU has a source of power
@@ -41,7 +41,7 @@ class HexDriveApp(app.App):
         if self.config is None:
             return False        
         # report app starting and which port it is running on
-        print(f"HexDrive App on port {self.config.port}")
+        print(f"HexDrive V{APP_VERSION} on port {self.config.port}")
         # Set Power Detect Pin to Input and Power Enable Pin to Output
         self._set_pin_direction(self.power_detect.pin,  1)
         self._set_pin_direction(self.power_control.pin, 0)  
@@ -101,7 +101,9 @@ class HexDriveApp(app.App):
                     print(f"H:{self.config.port}:Keep Alive Timeout")            
             # we keep retriggering in case anything else has corrupted the PWM outputs
 
-
+    def get_version(self) -> int:
+        return APP_VERSION
+    
     # Get the current status of the HexDrive App
     def get_status(self) -> bool:
         return not self.pwm_setup_failed


### PR DESCRIPTION
hexpansion now exposes function to return its app version.

main app attempts to call the new hexpansion function to check if hexpansion app needs to be upgraded. If it can't be called or returns version that isn't the current one (not strict about being higher or just that it isn't the same) then offers upgrade.

When hexpansions are inserted it takes time for the scheduler to be aware of their app (as it is sent from hexpansion app to scheduler via events) - so we have to be prepared that it can't be found immediately, yet still have a timeout of how long we will wait.  If app can't be found then also assume hexpansion app needs to be updated.

use of settings: use same convention as EEH app "appname"."setting". Refactor to have defaults and dynamically build full setting name for use in get setttings.

Differentiate bad error message (red) from good message (green) requesting reboop after successful upgrade.

secret feature (enabled by setting "badgebot.erase_eeprom") to enable eeprom on hexpansion in specified slot to be erased (useful to being able to reuse hexpansion to test initialisation and upgrade features.)

rename ports_with_upgraded_hexdrive to ports_with_latest_hexdrive as clearer language as hexdrive may have started with the latest version rather than be upgraded.

