### PR TITLE
Servo support

### DIFF
--- a/app.py
+++ b/app.py
@@ -29,7 +29,7 @@ from .utils import chain, draw_logo_animated
 # Hard coded to talk to EEPROMs on address 0x50 - because we know that is what is on the HexDrive Hexpansion
 # makes it a lot more efficient than scanning the I2C bus for devices and working out what they are
 
-CURRENT_APP_VERSION = 5 # Integer Version Number - checked against the EEPROM app.py version to determine if it needs updating
+CURRENT_APP_VERSION = 4 # Integer Version Number - checked against the EEPROM app.py version to determine if it needs updating
 
 # If you change the URL then you will need to regenerate the QR code
 _QR_CODE = [0x1fcf67f, 
@@ -675,6 +675,16 @@ class BadgeBotApp(app.App):
                             print(f"H:Found app on port {valid_port}")
                             if self.hexdrive_app.get_status():
                                 print(f"H:HexDrive [{valid_port}] OK")
+                                ##########################
+                                # TEST CODE HERE
+                                #self.hexdrive_app.set_freq(5000)
+                                #self.hexdrive_app.set_power(True)
+                                #self.hexdrive_app.set_keep_alive(10000)
+                                #self.hexdrive_app.set_servoposition(0,0)
+                                #self.hexdrive_app.set_servoposition(1,0)
+                                #self.hexdrive_app.set_servocentre(1600)
+                                #self.hexdrive_app.set_servoposition(1,50)
+                                ##########################
                                 self.current_state = STATE_MENU
                                 self.animation_counter = 0
                             else:

--- a/hexdrive.py
+++ b/hexdrive.py
@@ -11,7 +11,7 @@ from system.scheduler.events import RequestStopAppEvent
 import app
 
 # HexDrive.py App Version - used app.py to check if upgrade is required
-APP_VERSION = 4 
+APP_VERSION = 5 
 
 _ENABLE_PIN = 0	  # First LS pin used to enable the SMPSU
 _DETECT_PIN = 1   # Second LS pin used to sense if the SMPSU has a source of power

--- a/hexdrive.py
+++ b/hexdrive.py
@@ -11,7 +11,7 @@ from system.scheduler.events import RequestStopAppEvent
 import app
 
 # HexDrive.py App Version - parsed by app.py to check if upgrade is required
-APP_VERSION = 2648 
+APP_VERSION = 2647 
 
 _ENABLE_PIN = 0	  # First LS pin used to enable the SMPSU
 _DETECT_PIN = 1   # Second LS pin used to sense if the SMPSU has a source of power

--- a/hexdrive.py
+++ b/hexdrive.py
@@ -201,10 +201,10 @@ class HexDriveApp(app.App):
             # Ensure PWM frequency is suitable for use with Servos
             # otherwise the pulse width will not be accepted
             if self._logging:
-                print(f"H:{self.config.port}:PWM[{i}]:Force freq to {_DEFAULT_SERVO_FREQ}Hz for Servo")
+                print(f"H:{self.config.port}:PWM[{channel}]:Force freq to {_DEFAULT_SERVO_FREQ}Hz for Servo")
             self.PWMOutput[int(channel)].freq(_DEFAULT_SERVO_FREQ)
         # Scale servo position to PWM duty cycle (500-2500us)
-        pulse_width = int(self._servo_centre_ns + (position * 1000))
+        pulse_width = int(self._servo_centre_ns[channel] + (position * 1000))
         try:
             if pulse_width != self.PWMOutput[int(channel)].duty_ns():
                 self.PWMOutput[int(channel)].duty_ns(pulse_width)
@@ -217,6 +217,9 @@ class HexDriveApp(app.App):
         return True
 
     # Set the centre position for a specific servo output
+    # Note this does not change the current position of the servo
+    # it will only affect the position next time it is set
+    # you can use this to trim the centre position of the servo
     def set_servocentre(self, centre, channel=None) -> bool:
         if self.pwm_setup_failed:
             return False

--- a/hexdrive.py
+++ b/hexdrive.py
@@ -11,7 +11,7 @@ from system.scheduler.events import RequestStopAppEvent
 import app
 
 # HexDrive.py App Version - used app.py to check if upgrade is required
-APP_VERSION = 3 
+APP_VERSION = 4 
 
 _ENABLE_PIN = 0	  # First LS pin used to enable the SMPSU
 _DETECT_PIN = 1   # Second LS pin used to sense if the SMPSU has a source of power

--- a/hexdrive.py
+++ b/hexdrive.py
@@ -11,7 +11,7 @@ from system.scheduler.events import RequestStopAppEvent
 import app
 
 # HexDrive.py App Version - used app.py to check if upgrade is required
-APP_VERSION = 5 
+APP_VERSION = 4 
 
 _ENABLE_PIN = 0	  # First LS pin used to enable the SMPSU
 _DETECT_PIN = 1   # Second LS pin used to sense if the SMPSU has a source of power
@@ -47,7 +47,7 @@ class HexDriveApp(app.App):
         if self.config is None:
             return False        
         # report app starting and which port it is running on
-        print(f"HexDrive V{APP_VERSION} on port {self.config.port}")
+        print(f"HexDrive V{APP_VERSION} by RobotMad on port {self.config.port}")
         # Set Power Detect Pin to Input and Power Enable Pin to Output
         self._set_pin_direction(self.power_detect.pin,  1)  # input
         self._set_pin_direction(self.power_control.pin, 0)  # output
@@ -85,7 +85,7 @@ class HexDriveApp(app.App):
     async def _handle_stop_app(self, event):
         if event.app == self:
             if self._logging:
-                print(f"H:{self.config.port}:Stopping HexDrive App & Release PWM resources")
+                print(f"H:{self.config.port}:Stopping HexDrive App & Releasing PWM resources")
             self.deinitialise()
 
 

--- a/hexdrive.py
+++ b/hexdrive.py
@@ -17,7 +17,12 @@ _ENABLE_PIN = 0	  # First LS pin used to enable the SMPSU
 _DETECT_PIN = 1   # Second LS pin used to sense if the SMPSU has a source of power
 
 _DEFAULT_PWM_FREQ = 20000    
-_DEFAULT_KEEP_ALIVE_PERIOD = 1000  # 1 second
+_DEFAULT_SERVO_FREQ = 50            # 20mS period
+_MAX_SERVO_FREQ = 200               # 5mS period (can work with some Servos but not all)
+_DEFAULT_KEEP_ALIVE_PERIOD = 1000   # 1 second
+_SERVO_CENTRE_NS = 1500000          # 1500us
+
+_SYSTEM_I2C_BUS = 7
 
 class HexDriveApp(app.App):
 
@@ -29,45 +34,47 @@ class HexDriveApp(app.App):
         self.pwm_setup_failed = True
         self.time_since_last_update = 0
         self.outputs_energised = False
-        self.PWMOutput = [None] * len(self.config.pin)
+        self.PWMOutput = [None] * 4
         self.power_detect = self.config.ls_pin[_DETECT_PIN]
         self.power_control = self.config.ls_pin[_ENABLE_PIN]       
-
+        self._servo_centre_ns = [_SERVO_CENTRE_NS] * 4
         eventbus.on_async(RequestStopAppEvent, self._handle_stop_app, self)
 
         self.initialise()
 
     def initialise(self) -> bool:
+        self.pwm_setup_failed = True
         if self.config is None:
             return False        
         # report app starting and which port it is running on
         print(f"HexDrive V{APP_VERSION} on port {self.config.port}")
         # Set Power Detect Pin to Input and Power Enable Pin to Output
-        self._set_pin_direction(self.power_detect.pin,  1)
-        self._set_pin_direction(self.power_control.pin, 0)  
+        self._set_pin_direction(self.power_detect.pin,  1)  # input
+        self._set_pin_direction(self.power_control.pin, 0)  # output
         self.set_power(False)
         # Set all HexDrive Hexpansion HS pins to low level outputs
         for hs_pin in self.config.pin:
             hs_pin.value(0)    
-        # Allocate PWM generation to pins
-        for i_num, hs_pin in enumerate(self.config.pin):
-            try:
-                self.PWMOutput[i_num] = PWM(hs_pin, freq = _DEFAULT_PWM_FREQ, duty_u16 = 0)
-                if self._logging:
-                    print(f"H:{self.config.port}:PWM[{i_num}]:{self.PWMOutput[i_num]}")
-            except:
-                # There are a finite number of PWM resources so it is possible that we run out
-                print(f"H:{self.config.port}:PWM[{i_num}]:PWM allocation failed")
-                return False
-        self.pwm_setup_failed = False
+        if self.config.pin is not None and len(self.config.pin) == 4:
+            # Allocate PWM generation to pins
+            for channel, hs_pin in enumerate(self.config.pin):
+                try:
+                    self.PWMOutput[channel] = PWM(hs_pin, freq = _DEFAULT_PWM_FREQ, duty_u16 = 0)
+                    if self._logging:
+                        print(f"H:{self.config.port}:PWM[{channel}]:{self.PWMOutput[channel]}")
+                except:
+                    # There are a finite number of PWM resources so it is possible that we run out
+                    print(f"H:{self.config.port}:PWM[{channel}]: allocation failed")
+                    return False
+            self.pwm_setup_failed = False
         return not self.pwm_setup_failed
 
 
     def deinitialise(self) -> bool:
         # Turn off all PWM outputs & release resources
-        for i, pwm in enumerate(self.PWMOutput):
+        for channel, pwm in enumerate(self.PWMOutput):
             pwm.deinit()
-            self.PWMOutput[i] = None
+            self.PWMOutput[channel] = None
         self.set_power(False)
         for hs_pin in self.config.pin:
             hs_pin.value(0)          
@@ -78,7 +85,7 @@ class HexDriveApp(app.App):
     async def _handle_stop_app(self, event):
         if event.app == self:
             if self._logging:
-                print(f"H:{self.config.port}:Stopping HexDrive App")
+                print(f"H:{self.config.port}:Stopping HexDrive App & Release PWM resources")
             self.deinitialise()
 
 
@@ -101,9 +108,11 @@ class HexDriveApp(app.App):
                     print(f"H:{self.config.port}:Keep Alive Timeout")            
             # we keep retriggering in case anything else has corrupted the PWM outputs
 
+
     def get_version(self) -> int:
         return APP_VERSION
     
+
     # Get the current status of the HexDrive App
     def get_status(self) -> bool:
         return not self.pwm_setup_failed
@@ -113,8 +122,13 @@ class HexDriveApp(app.App):
     def set_logging(self, state):
         self._logging = state
 
-    
-    # Turn the SPMPSU on or off
+
+    # Get the current logging state
+    def get_logging(self) -> bool:
+        return self._logging
+
+
+    # Turn the SMPPSU on or off
     # Just because the SPMSU is turned off does not mean that the outputs are NOT energised
     # as there could be external battery power
     def set_power(self, state) -> bool:
@@ -130,6 +144,11 @@ class HexDriveApp(app.App):
         return self.power_state    
 
 
+    # Get the current state of the SMPSU enable pin
+    def get_power(self) -> bool:
+        return self.power_state
+
+
     # Get the current state of the SMPSU power source
     def get_booster_power(self) -> bool:
         return self._get_pin_state(self.power_detect.pin)
@@ -141,85 +160,133 @@ class HexDriveApp(app.App):
 
     
     # Only one PWM frequency (in Hz) is supported for all outputs due to timer limitations
+    # Use 50 to 200 for Servos and 5000 to 20000 for motors
     def set_freq(self, freq) -> bool:
         if self.pwm_setup_failed:
             return False
-        for i, pwm in enumerate(self.PWMOutput):
+        for channel, pwm in enumerate(self.PWMOutput):
             try:
-                pwm.freq(freq)
+                pwm.freq(int(freq))
                 if self._logging:
-                    print(f"H:{self.config.port}:PWM[{i}] freq: {freq}Hz")
+                    print(f"H:{self.config.port}:PWM[{channel}] freq: {int(freq)}Hz")
             except:
-                print(f"H:{self.config.port}:PWM[{i}] freq: {freq}Hz set failed")
+                print(f"H:{self.config.port}:PWM[{channel}] freq: set {int(freq)}Hz failed")
                 return False
         return True
     
+
+    # Get the current PWM frequency for a specific output
+    def get_freq(self, channel=0) -> int:
+        if self.pwm_setup_failed:
+            return 0
+        if channel < 0 or channel >= 4:
+            return 0
+        return self.PWMOutput[int(channel)].freq()
+    
+
     # set the pulse width for a specific servo output
+    # position is the offset (in us) from the centre position of the servo
     # Based on standard RC servos with centre at 1500us and range of 1000-2000us
-    # The position is a signed value from -1000 to 1000
-    def set_servoposition(self, i, position) -> bool:
+    # The position is a signed value from -1000 to 1000 which is scaled to 500-2500us
+    # This is a very wide range and may not be suitable for all servos, some will 
+    # only be happy with 1000-2000us (i.e. position in the range -500 to 500)
+    def set_servoposition(self, channel=0, position=0) -> bool:
         if self.pwm_setup_failed:
             return False
-        if i < 0 or i >= len(self.PWMOutput):
+        if channel < 0 or channel >= 4:
             return False
+        if abs(position) > 1000:
+            return False
+        if _MAX_SERVO_FREQ < self.PWMOutput[int(channel)].freq():
+            # Ensure PWM frequency is suitable for use with Servos
+            # otherwise the pulse width will not be accepted
+            if self._logging:
+                print(f"H:{self.config.port}:PWM[{i}]:Force freq to {_DEFAULT_SERVO_FREQ}Hz for Servo")
+            self.PWMOutput[int(channel)].freq(_DEFAULT_SERVO_FREQ)
         # Scale servo position to PWM duty cycle (500-2500us)
-        pulse_width = 1500000 + (position * 10)
+        pulse_width = int(self._servo_centre_ns + (position * 1000))
         try:
-            if pulse_width != self.PWMOutput[i].duty_ns():
-                self.PWMOutput[i].duty_ns(pulse_width)
+            if pulse_width != self.PWMOutput[int(channel)].duty_ns():
+                self.PWMOutput[int(channel)].duty_ns(pulse_width)
                 if self._logging:
-                    print(f"H:{self.config.port}:PWM[{i}]:{pulse_width//1000}us")
+                    print(f"H:{self.config.port}:PWM[{int(channel)}]:{pulse_width//1000}us")
         except:
-            print(f"H:{self.config.port}:PWM[{i}]:{position} set failed")
+            print(f"H:{self.config.port}:PWM[{int(channel)}]:{position} set failed")
             return False
+        self.time_since_last_update = 0
         return True
 
-        if self.set_pwmoutput(i, pwm):
-            self.time_since_last_update = 0
-            return True
-        return False 
+    # Set the centre position for a specific servo output
+    def set_servocentre(self, centre, channel=None) -> bool:
+        if self.pwm_setup_failed:
+            return False
+        if channel is not None and (channel < 0 or channel >= 4):
+            return False
+        if centre < 500 or centre > 2500:
+            return False
+        if channel is None:
+            self._servo_centre_ns = [int(centre * 1000)] * 4
+        else:    
+            self._servo_centre_ns[int(channel)] = int(centre * 1000)
+        return True
     
+
     # Set all 4 PWM duty cycles in one go using a signed value per motor channel (0-65535)
     def set_motors(self, outputs) -> bool:
         if self.pwm_setup_failed:
             return False
         self.outputs_energised = any(outputs)
-        for i, output in enumerate(outputs):
-            pwmA =  output if output > 0 else 0
-            pwmB = -output if output < 0 else 0
-            if not self.set_pwmoutput(i<<1, pwmA) or not self.set_pwmoutput((i<<1)+1, pwmB):
+        for motor, output in enumerate(outputs):
+            if abs(output) > 65535:
+                return False
+            pwmA =  int(output) if output > 0 else 0
+            pwmB = -int(output) if output < 0 else 0
+            if not self._set_pwmoutput(motor<<1, pwmA) or not self._set_pwmoutput((motor<<1)+1, pwmB):
                 return False
         self.time_since_last_update = 0
         return True
 
+
     # Set all 4 PWM duty cycles in one go using a tuple (0-65535)
-    def set_pwm(self, pwms) -> bool:
+    def set_pwm(self, duty_cycles) -> bool:
         if self.pwm_setup_failed:
             return False
-        self.outputs_energised = any(pwms)
-        for i, pwm in enumerate(pwms):
-            if not self.set_pwmoutput(i, pwm):
+        self.outputs_energised = any(duty_cycles)
+        for channel, duty_cycle in enumerate(duty_cycles): 
+            if not self._set_pwmoutput(channel, int(duty_cycle)):
                 return False
         self.time_since_last_update = 0
         return True
-    
+
+
+    # Get the current PWM duty cycle for a specific output (0-65535)
+    def get_pwm(self, channel=0) -> int:
+        if self.pwm_setup_failed:
+            return 0
+        if channel >= len(self.PWMOutput):
+            return 0
+        return self.PWMOutput[channel].duty_u16()
+
+
     # Set a single PWM duty cycle (0-65535) for a specific output
-    def set_pwmoutput(self, i, pwm) -> bool:
-        if i < 0 or i >= len(self.PWMOutput):
-            return False
+    def _set_pwmoutput(self, channel, duty_cycle) -> bool:
+        if duty_cycle < 0 or duty_cycle > 65535:
+            return False   
         try:
-            if pwm != self.PWMOutput[i].duty_u16():
-                self.PWMOutput[i].duty_u16(pwm)
+            if duty_cycle != self.PWMOutput[channel].duty_u16():
+                self.PWMOutput[channel].duty_u16(duty_cycle)
                 if self._logging:
-                    print(f"H:{self.config.port}:PWM[{i}]:{pwm}")
+                    print(f"H:{self.config.port}:PWM[{channel}]:{duty_cycle}")
         except:
-            print(f"H:{self.config.port}:PWM[{i}]:{pwm} set failed")
+            print(f"H:{self.config.port}:PWM[{channel}]:set {duty_cycle} failed")
             return False
         return True
-    
+
+
+    # Set the state of a specific LS output pin
     def _set_pin_state(self, pin, state):
         try:
-            i2c = I2C(7)
+            i2c = I2C(_SYSTEM_I2C_BUS)
             output_reg = i2c.readfrom_mem(pin[0], 0x02+pin[1], 1)[0]
             output_reg = (output_reg | pin[2]) if state else (output_reg & ~pin[2])
             i2c.writeto_mem(pin[0], 0x02+pin[1], bytes([output_reg]))
@@ -229,9 +296,10 @@ class HexDriveApp(app.App):
             print(f"H:{self.config.port}:access to I2C(7) failed: {e}")
 
 
+    # Get the state of a specific LS input pin
     def _get_pin_state(self, pin) -> bool:
         try:
-            i2c = I2C(7)
+            i2c = I2C(_SYSTEM_I2C_BUS)
             input_reg = i2c.readfrom_mem(pin[0], 0x00+pin[1], 1)[0]
             return (input_reg & pin[2]) != 0
         except Exception as e:
@@ -239,12 +307,13 @@ class HexDriveApp(app.App):
             return False
 
 
+    # Set the direction of a specific LS pin
     def _set_pin_direction(self, pin, direction):
         try:
             # Use a Try in case access to i2C(7) is blocked for apps in future
             # presumably if this happens then the code will have been updated to
             # handle the GPIO direction correctly anyway.
-            i2c = I2C(7)
+            i2c = I2C(_SYSTEM_I2C_BUS)
             config_reg = i2c.readfrom_mem(pin[0], 0x04+pin[1], 1)[0]
             config_reg = (config_reg | pin[2]) if (1 == direction) else (config_reg & ~pin[2])
             i2c.writeto_mem(pin[0], 0x04+pin[1], bytes([config_reg]))

--- a/utils.py
+++ b/utils.py
@@ -20,7 +20,6 @@ def roundtext(ctx, t, r, top=False):
     ctx.restore()
 
 def draw_logo_animated(ctx, rpm, animation_counter=0, messages=None, qr_code=None):
-    legw = .12
     # 0:black, 1:white, 2:yellow
     colours = [(0, 0, 0), (1, 1, 1), (1.0, 0.84, 0)]
 
@@ -61,8 +60,7 @@ def draw_logo_animated(ctx, rpm, animation_counter=0, messages=None, qr_code=Non
 # QR code data
 def draw_QRCode(ctx, qr_code, size=240, colour=(1,1,1)):
     qr_size = len( qr_code )
-    print(f"Drawing QR code of size {qr_size}x{qr_size}")
-
+    
     #   Draw background - assume already drawn
     #ctx.rgb(*colour).rectangle(-size/2, -size/2, size, size).fill()
 


### PR DESCRIPTION
signed duty cycle values to control two motors with just two values. 

**servo support:** 
control to set servo centre pulse width (default 1500us) per channel (no specified channel sets them all)
control to set servo pulse width (as a signed value about the centre) per channel
first time you try to set a servo the frequency for that channel is automatically adjusted to 50Hz, but you can request other frequencies.
parameter heavily checked to avoid crashes
comprehensive set of set and get commands.

App updated to show movement steps in colour and to use "FWD"/"REV" instead up "UP"/"DOWN"