### PR TITLE
Servo Tester UI

### DIFF
--- a/app.py
+++ b/app.py
@@ -1091,7 +1091,7 @@ class BadgeBotApp(app.App):
 
 ### MENU FUNCTIONALITY ###
 
-    def set_menu(self, menu_name: Literal["main"]):
+    def set_menu(self, menu_name = "main"):  #: Literal["main"]): does it work without the type hint?
         if self.menu is not None:
             self.menu._cleanup()
         self.current_menu = menu_name

--- a/app.py
+++ b/app.py
@@ -108,7 +108,7 @@ STATE_SERVO = 16          # Servo test
 
 # App states where user can minimise app
 _MINIMISE_VALID_STATES = [0, 1, 7, 12, 13, 14, 15]
-_LED_CONTROL_STATES    = [3, 4, 5, 6, 12, 13, 14, 15]
+_LED_CONTROL_STATES    = [0, 3, 4, 5, 6, 12, 13, 14, 15]
 
 # HexDrive Hexpansion constants
 _EEPROM_ADDR  = 0x50
@@ -531,6 +531,7 @@ class BadgeBotApp(app.App):
                 # There are currently no possible HexDrives plugged in
                 self._animation_counter = 0
                 self.current_state = STATE_WARNING
+                eventbus.emit(PatternDisable())                
             else:
                 self.current_state = STATE_WAIT
             return
@@ -546,9 +547,9 @@ class BadgeBotApp(app.App):
                 self.button_states.clear()
                 if self.current_state == STATE_WARNING:
                     self._animation_counter = 0
-                    self.current_state = STATE_LOGO
                 elif self.hexdrive_port is not None:
                     self.current_state = STATE_MENU
+                    eventbus.emit(PatternEnable())                    
                 else:
                     self.current_state = STATE_WARNING    
             else:
@@ -577,6 +578,7 @@ class BadgeBotApp(app.App):
                 self.button_states.clear()
                 self.current_state = STATE_WAIT
                 self.error_message = []
+                eventbus.emit(PatternEnable())                
             else:
                 for i in range(1,13):
                     tildagonos.leds[i] = (0,255,0) if self.current_state == STATE_MESSAGE else (255,0,0)       
@@ -721,10 +723,12 @@ class BadgeBotApp(app.App):
                                 print(f"H:HexDrive {valid_port}: Failed to initialise PWM resources")
                                 self.error_message = [f"HexDrive {valid_port}","PWM Init","Failed","Please","Reboop"]
                                 self.current_state = STATE_ERROR
+                                eventbus.emit(PatternDisable())                    
                         else:
                             print(f"H:HexDrive {valid_port}: App not found, please reboop")
                             self.error_message = [f"HexDrive {valid_port}","App not found.","Please","reboop"]
-                            self.current_state = STATE_ERROR                           
+                            self.current_state = STATE_ERROR
+                            eventbus.emit(PatternDisable())                    
                     else:
                         # Still have hexdrive on original port
                         self.current_state = STATE_MENU        
@@ -732,9 +736,11 @@ class BadgeBotApp(app.App):
                     self.hexdrive_port = None
                     self.hexdrive_app = None                      
                     self.current_state = STATE_REMOVED
+                    eventbus.emit(PatternDisable())                    
                 else:
                     self._animation_counter = 0                   
                     self.current_state = STATE_WARNING
+                    eventbus.emit(PatternDisable())                    
 
 ### END OF UI FOR HEXPANSION INITIALISATION AND UPGRADE ###
 
@@ -771,7 +777,8 @@ class BadgeBotApp(app.App):
                 if self._animation_counter > 10:
                     # after 10 seconds show the logo
                     self._animation_counter = 0
-                    self.current_state = STATE_LOGO                    
+                    self.current_state = STATE_LOGO
+                    eventbus.emit(PatternDisable())
         elif self.current_state == STATE_RECEIVE_INSTR:
             # Enable/disable scrolling and check for long press
             if self.button_states.get(BUTTON_TYPES["CONFIRM"]):

--- a/app.py
+++ b/app.py
@@ -756,7 +756,7 @@ class BadgeBotApp(app.App):
                 self._refresh = True
             else:
                 self.menu.update(delta)    
-                if self.menu.is_animating is not "none":
+                if self.menu.is_animating != "none":
                     print("Menu is animating")
                     self._refresh = True
         elif self.button_states.get(BUTTON_TYPES["CANCEL"]) and self.current_state in _MINIMISE_VALID_STATES:

--- a/app.py
+++ b/app.py
@@ -6,7 +6,8 @@ from math import cos, pi
 import settings
 import vfs
 from app_components.notification import Notification
-from app_components.tokens import label_font_size, twentyfour_pt
+from app_components.tokens import label_font_size, twentyfour_pt, clear_background
+from app_components import Menu
 from events.input import BUTTON_TYPES, Button, Buttons, ButtonUpEvent
 from frontboards.twentyfour import BUTTONS
 from machine import I2C
@@ -29,7 +30,7 @@ from .utils import chain, draw_logo_animated
 # Hard coded to talk to EEPROMs on address 0x50 - because we know that is what is on the HexDrive Hexpansion
 # makes it a lot more efficient than scanning the I2C bus for devices and working out what they are
 
-CURRENT_APP_VERSION = 3 # Integer Version Number - checked against the EEPROM app.py version to determine if it needs updating
+CURRENT_APP_VERSION = 4 # Integer Version Number - checked against the EEPROM app.py version to determine if it needs updating
 
 # If you change the URL then you will need to regenerate the QR code
 _QR_CODE = [0x1fcf67f, 
@@ -67,33 +68,47 @@ _BRIGHTNESS = 1.0
 _MAX_POWER = 65535
 _POWER_STEP_PER_TICK = 7500  # effectively the acceleration
 
+# Servo Tester - Defaults
+_SERVO_DEFAULT_STEP    = 50         # us per step    
+_SERVO_DEFAULT_CENTRE  = 1500       # us
+_SERVO_DEFAULT_RANGE   = 500        # +/- 500us from centre
+_SERVO_DEFAULT_RATE    = 250        # us per s
+_SERVO_DEFAULT_MODE    = 0          # Off    
+_SERVO_MAX_RATE        = 2000       # us per s
+_SERVO_MIN_RATE        = 50         # us per s
+_SERVO_RATE_STEP       = 50         # us per s
+
 # Timings
 _TICK_MS       =  10 # Smallest unit of change for power, in ms
 _USER_DRIVE_MS =  50 # User specifed drive durations, in ms
 _USER_TURN_MS  =  20 # User specifed turn durations, in ms
 _LONG_PRESS_MS = 750 # Time for long button press to register, in ms
 _RUN_COUNTDOWN_MS = 5000 # Time after running program until drive starts, in ms
+_AUTO_REPEAT_MS = 150 # Time between auto-repeats, in ms
 
 # App states
 STATE_INIT = -1
 STATE_WARNING = 0
 STATE_MENU = 1
-STATE_RECEIVE_INSTR = 2
-STATE_COUNTDOWN = 3
-STATE_RUN = 4
-STATE_DONE = 5
-STATE_WAIT = 6            # Between Hexpansion initialisation and upgrade steps  
-STATE_DETECTED = 7        # Hexpansion ready for EEPROM initialisation
-STATE_UPGRADE = 8         # Hexpansion ready for EEPROM upgrade
-STATE_ERASE = 9           # Hexpansion ready for EEPROM erase
-STATE_PROGRAMMING = 10    # Hexpansion EEPROM programming
-STATE_REMOVED = 11        # Hexpansion removed
-STATE_ERROR = 12          # Hexpansion error
-STATE_MESSAGE = 13        # Message display
-STATE_LOGO = 14           # Logo display
+STATE_HELP = 2
+STATE_RECEIVE_INSTR = 3
+STATE_COUNTDOWN = 4
+STATE_RUN = 5
+STATE_DONE = 6
+STATE_WAIT = 7            # Between Hexpansion initialisation and upgrade steps  
+STATE_DETECTED = 8        # Hexpansion ready for EEPROM initialisation
+STATE_UPGRADE = 9         # Hexpansion ready for EEPROM upgrade
+STATE_ERASE = 10          # Hexpansion ready for EEPROM erase
+STATE_PROGRAMMING = 11    # Hexpansion EEPROM programming
+STATE_REMOVED = 12        # Hexpansion removed
+STATE_ERROR = 13          # Hexpansion error
+STATE_MESSAGE = 14        # Message display
+STATE_LOGO = 15           # Logo display
+STATE_SERVO = 16          # Servo test
 
 # App states where user can minimise app
-MINIMISE_VALID_STATES = [0, 1, 2, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]
+_MINIMISE_VALID_STATES = [0, 1, 7, 12, 13, 14, 15]
+_LED_CONTROL_STATES    = [3, 4, 5, 6, 12, 13, 14, 15]
 
 # HexDrive Hexpansion constants
 _EEPROM_ADDR  = 0x50
@@ -107,18 +122,23 @@ _HEXDRIVE_PID = 0xCBCB
 _LOGGING = False
 _ERASE_EEPROM = 0   # Slot for user to set if they want to erase EEPROMs on HexDrives
 
+# 
+_main_menu_items = ["Turtle/Logo", "Servo Test"] #, "Settings"]
+_settings_menu_items = ["Servo Step"]
 
 class BadgeBotApp(app.App):
     def __init__(self):
         super().__init__()
+        # UI Button Controls
         self.button_states = Buttons(self)
         self.last_press: Button = BUTTON_TYPES["CANCEL"]
         self.long_press_delta = 0
+        self._auto_repeat = 0
 
         # UI Feature Controls
+        self._refresh = True
         self.rpm = 5                    # logo rotation speed in RPM
-        self.animation_counter = 0
-
+        self._animation_counter = 0
         self.qr_code = _QR_CODE
         self.b_msg = "BadgeBot"
         self.t_msg = "RobotMad"
@@ -126,6 +146,13 @@ class BadgeBotApp(app.App):
         self.scroll_offset = 0
         self.notification = None
         self.error_message = []
+        self.current_menu = "main"
+        self.menu = Menu(
+            self,
+            _main_menu_items,
+            select_handler=self._main_menu_select_handler,
+            back_handler=self._menu_back_handler,
+        )
 
         # BadgeBot Control Sequence Variables
         self.run_countdown_elapsed_ms = 0
@@ -143,6 +170,7 @@ class BadgeBotApp(app.App):
         self._default_settings['brightness']    = _BRIGHTNESS
         self._default_settings['logging']       = _LOGGING
         self._default_settings['erase_eeprom']  = _ERASE_EEPROM
+        self._default_settings['servo_step']    = _SERVO_DEFAULT_STEP
         self.settings = {}
         self.update_settings()   
 
@@ -160,6 +188,15 @@ class BadgeBotApp(app.App):
         eventbus.on_async(HexpansionInsertionEvent, self._handle_hexpansion_insertion, self)
         eventbus.on_async(HexpansionRemovalEvent, self._handle_hexpansion_removal, self)
         eventbus.on_async(RequestStartAppEvent, self._handle_start_app, self)
+
+        # Servo Tester
+        self.servo        = [None]*4                    # Servo Positions
+        self.servo_centre = [_SERVO_DEFAULT_CENTRE]*4   # Trim Servo Centre
+        self.servo_range  = [_SERVO_DEFAULT_RANGE]*4    # Limit Servo Range
+        self.servo_rate   = [_SERVO_DEFAULT_RATE]*4     # Servo Rate of Change
+        self.servo_mode   = [_SERVO_DEFAULT_MODE]*4     # Servo Mode [0:Position, 1: Scan]
+        self.servo_selected = 0
+        self._servo_modes = ['Off','Position','Scanning']
 
         # Overall app state (controls what is displayed and what user inputs are accepted)
         self.current_state = STATE_INIT
@@ -207,7 +244,7 @@ class BadgeBotApp(app.App):
             self.hexpansion_update_required = True
 
     async def _gain_focus(self, event: RequestForegroundPushEvent):
-        if event.app is self:
+        if event.app is self and self.current_state in _LED_CONTROL_STATES:
             eventbus.emit(PatternDisable())
 
     async def _lose_focus(self, event: RequestForegroundPopEvent):
@@ -227,9 +264,8 @@ class BadgeBotApp(app.App):
             cur_time = time.ticks_ms()
             delta_ticks = time.ticks_diff(cur_time, last_time)
             self.background_update(delta_ticks)
-             # If we want to be kind we could make this variable depending on app state
-             # i.e. on transition into run set this lower
-            await asyncio.sleep(0.01)
+            s = 0.01 if self.current_state == STATE_RUN else 0.05
+            await asyncio.sleep(s)
             last_time = cur_time
 
 
@@ -482,32 +518,34 @@ class BadgeBotApp(app.App):
     ### MAIN APP CONTROL FUNCTIONS ###
 
     def update(self, delta):
-        self.clear_leds()
         if self.notification:
             self.notification.update(delta)
+
+        previous_state = self.current_state
 
         ### START UI FOR HEXPANSION INITIALISATION AND UPGRADE ###
         if self.current_state == STATE_INIT:
             # One Time initialisation      
-            eventbus.emit(PatternDisable())
             self.scan_ports()
             if (len(self.ports_with_hexdrive) == 0) and (len(self.ports_with_blank_eeprom) == 0):
                 # There are currently no possible HexDrives plugged in
-                self.animation_counter = 0
+                self._animation_counter = 0
                 self.current_state = STATE_WARNING
             else:
                 self.current_state = STATE_WAIT
             return
+        
         if self.hexpansion_update_required:
             # something has changed in the hexpansion ports            
             self.hexpansion_update_required = False
             self.current_state = STATE_WAIT
+        
         if self.current_state == STATE_WARNING or self.current_state == STATE_LOGO:
             if self.button_states.get(BUTTON_TYPES["CONFIRM"]):
                 # Warning has been acknowledged by the user
                 self.button_states.clear()
                 if self.current_state == STATE_WARNING:
-                    self.animation_counter = 0
+                    self._animation_counter = 0
                     self.current_state = STATE_LOGO
                 elif self.hexdrive_port is not None:
                     self.current_state = STATE_MENU
@@ -516,17 +554,18 @@ class BadgeBotApp(app.App):
             else:
                 # "CANCEL" button is handled below in common for all MINIMISE_VALID_STATES 
                 # Show the warning screen for 10 seconds
-                self.animation_counter += delta/1000
-                if self.current_state == STATE_WARNING and self.animation_counter > 10:
+                self._animation_counter += delta/1000
+                self._refresh = True
+                if self.current_state == STATE_WARNING and self._animation_counter > 10:
                     # after 10 seconds show the logo
-                    self.animation_counter = 0
+                    self._animation_counter = 0
                     self.current_state = STATE_LOGO
                 elif self.current_state == STATE_LOGO:
                     # LED management - to match rotating logo:
                     for i in range(1,13):
                         colour = (255, 241, 0)      # custom Robotmad shade of yellow                                
                         # raised cosine cubed wave
-                        wave = self.settings['brightness'] * pow((1.0 + cos(((i) *  pi / 1.5) - (self.rpm * self.animation_counter * pi / 7.5)))/2.0, 3)    
+                        wave = self.settings['brightness'] * pow((1.0 + cos(((i) *  pi / 1.5) - (self.rpm * self._animation_counter * pi / 7.5)))/2.0, 3)    
                         # 4 sides each projecting a pattern of 3 LEDs (12 LEDs in total)
                         tildagonos.leds[i] = tuple(int(wave * j) for j in colour)                                                     
                 else: # STATE_WARNING
@@ -566,52 +605,53 @@ class BadgeBotApp(app.App):
                 self.detected_port = None
             else:
                 print("H:Error - no port to program")    
-        if self.current_state in MINIMISE_VALID_STATES:
-            if self.current_state == STATE_DETECTED:
-                # We are currently asking the user if they want hexpansion EEPROM initialising
-                if self.button_states.get(BUTTON_TYPES["CONFIRM"]):
-                    # Yes
-                    self.button_states.clear()
-                    self.current_state = STATE_PROGRAMMING        
-                elif self.button_states.get(BUTTON_TYPES["CANCEL"]):
-                    # No
-                    print("H:Initialise Cancelled")
-                    self.button_states.clear()
-                    self.detected_port = None
-                    self.current_state = STATE_WAIT
-            elif self.current_state == STATE_ERASE:
-                # We are currently asking the user if they want hexpansion EEPROM Erased                
-                if self.button_states.get(BUTTON_TYPES["CONFIRM"]):
-                    # Yes
-                    self.button_states.clear()
-                    if self.erase_eeprom(self.erase_port, _EEPROM_ADDR):
-                        self.error_message = ["Erased:","Please","reboop"]
-                        self.notification = Notification("Erased", port = self.erase_port)
-                        self.erase_port = None
-                        self.current_state = STATE_MESSAGE                  
-                    else:
-                        self.notification = Notification("Failed", port = self.erase_port)
-                        self.error_message = ["EEPROM","erasure","failed"]
-                        self.current_state = STATE_ERROR                       
-                elif self.button_states.get(BUTTON_TYPES["CANCEL"]):
-                    # No
-                    print("H:Erase Cancelled")
-                    self.button_states.clear()
+       
+        elif self.current_state == STATE_DETECTED:
+            # We are currently asking the user if they want hexpansion EEPROM initialising
+            if self.button_states.get(BUTTON_TYPES["CONFIRM"]):
+                # Yes
+                self.button_states.clear()
+                self.current_state = STATE_PROGRAMMING        
+            elif self.button_states.get(BUTTON_TYPES["CANCEL"]):
+                # No
+                print("H:Initialise Cancelled")
+                self.button_states.clear()
+                self.detected_port = None
+                self.current_state = STATE_WAIT
+        elif self.current_state == STATE_ERASE:
+            # We are currently asking the user if they want hexpansion EEPROM Erased                
+            if self.button_states.get(BUTTON_TYPES["CONFIRM"]):
+                # Yes
+                self.button_states.clear()
+                if self.erase_eeprom(self.erase_port, _EEPROM_ADDR):
+                    self.error_message = ["Erased:","Please","reboop"]
+                    self.notification = Notification("Erased", port = self.erase_port)
                     self.erase_port = None
-                    self.current_state = STATE_WAIT                        
-            elif self.current_state == STATE_UPGRADE:
-                # We are currently asking the user if they want hexpansion App upgrading with latest App.mpy                
-                if self.button_states.get(BUTTON_TYPES["CONFIRM"]):
-                    # Yes
-                    self.button_states.clear()
-                    self.current_state = STATE_PROGRAMMING
-                elif self.button_states.get(BUTTON_TYPES["CANCEL"]):
-                    # No
-                    print("H:Upgrade Cancelled")
-                    self.button_states.clear()
-                    self.upgrade_port = None
-                    self.current_state = STATE_WAIT                    
-            elif 0 < len(self.ports_with_blank_eeprom):
+                    self.current_state = STATE_MESSAGE                  
+                else:
+                    self.notification = Notification("Failed", port = self.erase_port)
+                    self.error_message = ["EEPROM","erasure","failed"]
+                    self.current_state = STATE_ERROR                       
+            elif self.button_states.get(BUTTON_TYPES["CANCEL"]):
+                # No
+                print("H:Erase Cancelled")
+                self.button_states.clear()
+                self.erase_port = None
+                self.current_state = STATE_WAIT                        
+        elif self.current_state == STATE_UPGRADE:
+            # We are currently asking the user if they want hexpansion App upgrading with latest App.mpy                
+            if self.button_states.get(BUTTON_TYPES["CONFIRM"]):
+                # Yes
+                self.button_states.clear()
+                self.current_state = STATE_PROGRAMMING
+            elif self.button_states.get(BUTTON_TYPES["CANCEL"]):
+                # No
+                print("H:Upgrade Cancelled")
+                self.button_states.clear()
+                self.upgrade_port = None
+                self.current_state = STATE_WAIT
+        elif self.current_state in _MINIMISE_VALID_STATES:                                        
+            if 0 < len(self.ports_with_blank_eeprom):
                 # if there are any ports with blank eeproms
                 # Show the UI prompt and wait for button press
                 self.detected_port = self.ports_with_blank_eeprom.pop()
@@ -621,7 +661,7 @@ class BadgeBotApp(app.App):
                 # if there are any ports with HexDrives - check if they need upgrading/erasing
                 if self.waiting_app_port is None:
                     self.waiting_app_port = self.ports_with_hexdrive.pop()
-                    self.animation_counter = 0  #timeout
+                    self._animation_counter = 0  #timeout
                 if self.settings['erase_eeprom'] == self.waiting_app_port:
                     # if the user has set a port to erase EEPROMs on
                     # Show the UI prompt and wait for button press
@@ -638,13 +678,13 @@ class BadgeBotApp(app.App):
                         except Exception as e:
                             hexdrive_app_version = 0
                             print(f"H:Error getting HexDrive app version - assume old: {e}")
-                    elif 5.0 < self.animation_counter:
+                    elif 5.0 < self._animation_counter:
                         print("H:Timeout waiting for HexDrive app to be started - assume it needs upgrading")
                         hexdrive_app_version = 0
                     else:
-                        if 0 == self.animation_counter:
+                        if 0 == self._animation_counter:
                             print(f"H:No app found on port {self.waiting_app_port} - WAITING for app to appear in Scheduler")
-                        self.animation_counter += delta/1000
+                        self._animation_counter += delta/1000
                         return                     
                     if hexdrive_app_version == CURRENT_APP_VERSION:    
                         print(f"H:HexDrive on port {self.waiting_app_port} has latest App")
@@ -657,7 +697,7 @@ class BadgeBotApp(app.App):
                         self.notification = Notification("Upgrade?", port = self.upgrade_port)
                         self.current_state = STATE_UPGRADE                             
                 self.waiting_app_port = None
-                self.animation_counter = 0
+                self._animation_counter = 0
             elif self.current_state == STATE_WAIT: 
                 if 0 < len(self.ports_with_latest_hexdrive):
                     # We have at least one HexDrive with the latest App.mpy
@@ -675,18 +715,8 @@ class BadgeBotApp(app.App):
                             print(f"H:Found app on port {valid_port}")
                             if self.hexdrive_app.get_status():
                                 print(f"H:HexDrive [{valid_port}] OK")
-                                ##########################
-                                # TEST CODE HERE
-                                #self.hexdrive_app.set_freq(5000)
-                                #self.hexdrive_app.set_power(True)
-                                #self.hexdrive_app.set_keep_alive(10000)
-                                #self.hexdrive_app.set_servoposition(0,0)
-                                #self.hexdrive_app.set_servoposition(1,0)
-                                #self.hexdrive_app.set_servocentre(1600)
-                                #self.hexdrive_app.set_servoposition(1,50)
-                                ##########################
                                 self.current_state = STATE_MENU
-                                self.animation_counter = 0
+                                self._animation_counter = 0
                             else:
                                 print(f"H:HexDrive {valid_port}: Failed to initialise PWM resources")
                                 self.error_message = [f"HexDrive {valid_port}","PWM Init","Failed","Please","Reboop"]
@@ -703,25 +733,45 @@ class BadgeBotApp(app.App):
                     self.hexdrive_app = None                      
                     self.current_state = STATE_REMOVED
                 else:
-                    self.animation_counter = 0                   
+                    self._animation_counter = 0                   
                     self.current_state = STATE_WARNING
+
 ### END OF UI FOR HEXPANSION INITIALISATION AND UPGRADE ###
 
-        if self.button_states.get(BUTTON_TYPES["CANCEL"]) and self.current_state in MINIMISE_VALID_STATES and self.current_state != STATE_DONE:
+        if self.current_state == STATE_MENU:
+            if self.current_menu is None:
+                self.current_menu = "main"
+                self.menu = Menu(
+                    self,
+                    _main_menu_items,
+                    select_handler=self._main_menu_select_handler,
+                    back_handler=self._menu_back_handler,
+                )
+                self._refresh = True
+            else:
+                self.menu.update(delta)    
+                if self.menu.is_animating is not "none":
+                    print("Menu is animating")
+                    self._refresh = True
+        elif self.button_states.get(BUTTON_TYPES["CANCEL"]) and self.current_state in _MINIMISE_VALID_STATES:
             self.button_states.clear()
             self.minimise()
-        elif self.current_state == STATE_MENU:
-            # Exit start menu
-            if self.button_states.get(BUTTON_TYPES["CONFIRM"]):
+        elif self.current_state == STATE_HELP:
+            if self.button_states.get(BUTTON_TYPES["CANCEL"]):
+                self.current_state = STATE_MENU
+                self.button_states.clear()
+            elif self.button_states.get(BUTTON_TYPES["CONFIRM"]):
                 self.is_scroll = True   # so that release of this button will CLEAR Scroll mode
                 self.current_state = STATE_RECEIVE_INSTR
+                eventbus.emit(PatternDisable())
                 self.button_states.clear()
-            # Show the instructions screen for 10 seconds
-            self.animation_counter += delta/1000
-            if self.animation_counter > 10:
-                # after 10 seconds show the logo
-                self.animation_counter = 0
-                self.current_state = STATE_LOGO
+            else:            
+                # Show the help for 10 seconds
+                self._animation_counter += delta/1000
+                if self._animation_counter > 10:
+                    # after 10 seconds show the logo
+                    self._animation_counter = 0
+                    self.current_state = STATE_LOGO                    
         elif self.current_state == STATE_RECEIVE_INSTR:
             # Enable/disable scrolling and check for long press
             if self.button_states.get(BUTTON_TYPES["CONFIRM"]):
@@ -736,23 +786,30 @@ class BadgeBotApp(app.App):
                 if self.is_scroll:
                     if self.button_states.get(BUTTON_TYPES["DOWN"]):
                         self.scroll_offset -= 1
+                        self._refresh = True                            
                     elif self.button_states.get(BUTTON_TYPES["UP"]):
                         self.scroll_offset += 1
+                        self._refresh = True
                     self.button_states.clear()
                 # Instruction button presses
                 elif self.button_states.get(BUTTON_TYPES["RIGHT"]):
                     self._handle_instruction_press(BUTTON_TYPES["RIGHT"])
                     self.button_states.clear()
+                    self._refresh = True
                 elif self.button_states.get(BUTTON_TYPES["LEFT"]):
                     self._handle_instruction_press(BUTTON_TYPES["LEFT"])
                     self.button_states.clear()
+                    self._refresh = True
                 elif self.button_states.get(BUTTON_TYPES["UP"]):
                     self._handle_instruction_press(BUTTON_TYPES["UP"])
                     self.button_states.clear()
+                    self._refresh = True
                 elif self.button_states.get(BUTTON_TYPES["DOWN"]):
                     self._handle_instruction_press(BUTTON_TYPES["DOWN"])
                     self.button_states.clear()
+                    self._refresh = True
             # LED management
+            self.clear_leds()
             if self.last_press == BUTTON_TYPES["RIGHT"]:
                 # Green = Starboard = Right
                 tildagonos.leds[2]  = (0, 255, 0)
@@ -770,94 +827,220 @@ class BadgeBotApp(app.App):
                 tildagonos.leds[6]  = (255, 0, 255)
                 tildagonos.leds[7]  = (255, 0, 255)
         elif self.current_state == STATE_COUNTDOWN:
+            self.clear_leds()
             self.run_countdown_elapsed_ms += delta
             if self.run_countdown_elapsed_ms >= _RUN_COUNTDOWN_MS:
                 self.power_plan_iter = chain(*(instr.power_plan for instr in self.instructions))
-                self.hexdrive_app.set_power(True)
+                if self.hexdrive_app is not None:
+                    self.hexdrive_app.set_power(True)
                 self.current_state = STATE_RUN
         elif self.current_state == STATE_RUN:
+            self.clear_leds()
             # Run is primarily managed in the background update
             pass
         elif self.current_state == STATE_DONE:
             if self.button_states.get(BUTTON_TYPES["CANCEL"]):
-                self.hexdrive_app.set_power(False)
-                self.reset()
+                if self.hexdrive_app is not None:
+                    self.hexdrive_app.set_power(False)
+                self.reset_robot()
+                eventbus.emit(PatternEnable())
                 self.button_states.clear()
             elif self.button_states.get(BUTTON_TYPES["CONFIRM"]):
-                self.hexdrive_app.set_power(False)
+                if self.hexdrive_app is not None:
+                    self.hexdrive_app.set_power(False)
                 self.run_countdown_elapsed_ms = 1   # avoid "6" appearing on screen at all
                 self.current_power_duration = ((0,0,0,0), 0)
-                self.current_state = STATE_COUNTDOWN                       
+                self.current_state = STATE_COUNTDOWN
                 self.button_states.clear()
-        if self.settings['brightness'] < 1.0:
-            # Scale brightness
-            for i in range(1,13):
-                tildagonos.leds[i] = tuple(int(j * self.settings['brightness']) for j in tildagonos.leds[i])                            
-        tildagonos.leds.write()
+        elif self.current_state == STATE_SERVO:
+            # Servo Tester:
+            # Up/Down to select Servo
+            # Left/Right to adjust position
+                # TODO if in Trim mode then adjust the centre position
+                # TODO keep alive
+            if self.button_states.get(BUTTON_TYPES["RIGHT"]):
+                if self._auto_repeat_check(delta):
+                    if self.servo_mode[self.servo_selected] == 2:
+                        # as the rate changes sign when it reaches the range, we must be careful to modify it in the correct direction
+                        if self.servo_rate[self.servo_selected] < 0:
+                            self.servo_rate[self.servo_selected] = self.servo_rate[self.servo_selected] - _SERVO_RATE_STEP
+                            if -_SERVO_MAX_RATE > self.servo_rate[self.servo_selected]:
+                                self.servo_rate[self.servo_selected] = -_SERVO_MAX_RATE
+                        else:
+                            self.servo_rate[self.servo_selected] = self.servo_rate[self.servo_selected] + _SERVO_RATE_STEP
+                            if _SERVO_MAX_RATE < self.servo_centre[self.servo_selected]:
+                                self.servo_rate[self.servo_selected] = _SERVO_MAX_RATE
+                    else:
+                        if self.servo[self.servo_selected] is None:
+                            self.servo[self.servo_selected] = 0
+                        self.servo_mode[self.servo_selected] = 1    
+                        self.servo[self.servo_selected] = self.servo[self.servo_selected] + self.settings['servo_step']
+                        if self.servo_range[self.servo_selected] < self.servo[self.servo_selected]:
+                            self.servo[self.servo_selected] = self.servo_range[self.servo_selected]
+                    self._refresh = True
+            elif self.button_states.get(BUTTON_TYPES["LEFT"]):
+                if self._auto_repeat_check(delta):
+                    if self.servo_mode[self.servo_selected] == 2:
+                        # as the rate changes sign when it reaches the range, we must be careful to modify it in the correct direction
+                        if self.servo_rate[self.servo_selected] < 0:
+                            self.servo_rate[self.servo_selected] = self.servo_rate[self.servo_selected] + _SERVO_RATE_STEP
+                            if -_SERVO_MIN_RATE < self.servo_rate[self.servo_selected]:
+                                self.servo_rate[self.servo_selected] = -_SERVO_MIN_RATE
+                        else:
+                            self.servo_rate[self.servo_selected] = self.servo_rate[self.servo_selected] - _SERVO_RATE_STEP
+                            if _SERVO_MIN_RATE > self.servo_centre[self.servo_selected]:
+                                self.servo_rate[self.servo_selected] = _SERVO_MIN_RATE
+                        #print(f"Servo {self.servo_selected} Rate: {self.servo_rate[self.servo_selected]}")                       
+                    else:
+                        if self.servo[self.servo_selected] is None:
+                            self.servo[self.servo_selected] = 0                        
+                        self.servo_mode[self.servo_selected] = 1    
+                        self.servo[self.servo_selected] = self.servo[self.servo_selected] - self.settings['servo_step']
+                        if -self.servo_range[self.servo_selected] > self.servo[self.servo_selected]:
+                            self.servo[self.servo_selected] = -self.servo_range[self.servo_selected]
+                    self._refresh = True
+            elif self.button_states.get(BUTTON_TYPES["UP"]):
+                self.servo_selected = (self.servo_selected - 1) % 4
+                self._refresh = True
+                self.button_states.clear()
+            elif self.button_states.get(BUTTON_TYPES["DOWN"]):
+                self.servo_selected = (self.servo_selected + 1) % 4
+                self._refresh = True
+                self.button_states.clear()
+            elif self.button_states.get(BUTTON_TYPES["CANCEL"]):
+                if self.hexdrive_app is not None:
+                    self.hexdrive_app.set_power(False)
+                    self.hexdrive_app.set_servoposition()   # All Off
+                self.current_state = STATE_MENU
+                self.button_states.clear()
+            elif self.button_states.get(BUTTON_TYPES["CONFIRM"]): #Toggle Mode
+                self.servo_mode[self.servo_selected] = (self.servo_mode[self.servo_selected] + 1) % 3
+                if self.servo_mode[self.servo_selected] == 0:
+                    self.hexdrive_app.set_servoposition(self.servo_selected, None)
+                else:
+                    self._refresh = True
+                self.button_states.clear()
+                self.notification = Notification(f"Servo {self.servo_selected}:   {self._servo_modes[self.servo_mode[self.servo_selected]]}")
+
+            if self.current_state == STATE_SERVO:   # check we are still acutally in servo mode
+                for i in range(4):
+                    if self.servo_mode[i] == 2:
+                        # for any servo set to Scan mode, update the position
+                        if self.servo[self.servo_selected] is None:
+                            self.servo[self.servo_selected] = 0                        
+                        self.servo[i] = self.servo[i] + (self.servo_rate[i] * delta / 1000)
+                        if self.servo_range[i] < self.servo[i]:
+                            # swap direction
+                            self.servo_rate[i] = -self.servo_rate[i]
+                            self.servo[i] = self.servo_range[i]
+                        elif -self.servo_range[i] > self.servo[i]:
+                            # swap direction
+                            self.servo_rate[i] = -self.servo_rate[i]
+                            self.servo[i] = -self.servo_range[i]
+                        self._refresh = True
+                    if self._refresh and self.hexdrive_app is not None and self.servo_mode[i] != 0 and self.servo[i] is not None:
+                        # scanning servo or the selected servo
+                        self.hexdrive_app.set_servoposition(i, int(self.servo[i]))
+
+        if self.current_state != previous_state:
+            # something has changed - so worth redrawing
+            self._refresh = True
+
+        if self.current_state in _LED_CONTROL_STATES:
+            if self.settings['brightness'] < 1.0:
+                # Scale brightness
+                for i in range(1,13):
+                    tildagonos.leds[i] = tuple(int(j * self.settings['brightness']) for j in tildagonos.leds[i])                            
+            tildagonos.leds.write()
 
 
     def draw(self, ctx):
-        ctx.save()
-        ctx.font_size = label_font_size
-        if self.current_state == STATE_LOGO:
-            draw_logo_animated(ctx, self.rpm, self.animation_counter, [self.b_msg, self.t_msg], self.qr_code)
-        # Scroll mode indicator
-        elif self.is_scroll:
-            ctx.rgb(0,0.2,0).rectangle(-120,-120,240,240).fill()
-        else:
-            ctx.rgb(0,0,0.2).rectangle(-120,-120,240,240).fill()
-        # Main screen content 
-        if   self.current_state == STATE_WARNING:
-            self.draw_message(ctx, ["BadgeBot requires","HexDrive hexpansion","from RobotMad","github.com","/TeamRobotmad","/BadgeBot"], [(1,1,1),(1,1,0),(1,1,0),(1,1,1),(1,1,1),(1,1,1)], label_font_size)
-        elif self.current_state == STATE_REMOVED:
-            self.draw_message(ctx, ["HexDrive","removed","Please reinsert"], [(1,1,0),(1,1,1),(1,1,1)], label_font_size)      
-        elif self.current_state == STATE_DETECTED:
-            self.draw_message(ctx, ["Hexpansion","detected in",f"Slot {self.detected_port}","Init EEPROM","as HexDrive?"], [(1,1,1),(1,1,1),(0,0,1),(1,1,1),(1,1,0)], label_font_size)
-        elif self.current_state == STATE_ERASE:
-            self.draw_message(ctx, ["HexDrive","detected in",f"Slot {self.erase_port}","Erase","EEPROM?"], [(1,1,0),(1,1,1),(0,0,1),(1,0,0),(1,0,0)], label_font_size)             
-        elif self.current_state == STATE_UPGRADE:
-            self.draw_message(ctx, ["HexDrive","detected in",f"Slot {self.upgrade_port}","Upgrade","HexDrive app?"], [(1,1,0),(1,1,1),(0,0,1),(1,1,1),(1,1,1)], label_font_size)             
-        elif self.current_state == STATE_PROGRAMMING:
-            self.draw_message(ctx, ["HexDrive:","Programming","EEPROM","Please wait..."], [(1,1,0),(1,1,1),(1,1,1),(1,1,1)], label_font_size)            
-        elif self.current_state == STATE_MENU:
-            self.draw_message(ctx, ["BadgeBot","To Program:","Press C","When finished:","Long press C"], [(1,1,0),(1,1,1),(1,1,1),(1,1,1),(1,1,1)], label_font_size)
-        elif self.current_state == STATE_ERROR:
-            self.draw_message(ctx, self.error_message, [(1,0,0)]*len(self.error_message), label_font_size)
-        elif self.current_state == STATE_MESSAGE:
-            self.draw_message(ctx, self.error_message, [(0,1,0)]*len(self.error_message), label_font_size)            
-        elif self.current_state == STATE_RECEIVE_INSTR:
-            # Display list of movements
-            for i_num, instr in enumerate(["START"] + self.instructions + [self.current_instruction, "END"]):
-                # map the instruction to a colour & change language from up/down to fwd/rev
-                colour = (1,1,1)
-                if instr is not None:
-                    direction = str(instr).split()[0]
-                    print(direction)
-                    if   direction == "UP":
-                        instr = "FWD " + str(instr).split()[1]
-                        colour = (0,1,1)
-                    elif direction == "DOWN":
-                        instr = "REV " + str(instr).split()[1]
-                        colour = (1,0,1)
-                    elif direction == "LEFT":
-                        colour = (1,0,0)
-                    elif direction == "RIGHT":
-                        colour = (0,1,0)            
-                ctx.rgb(*colour).move_to(H_START, V_START + label_font_size * (self.scroll_offset + i_num)).text(str(instr))
-        elif self.current_state == STATE_COUNTDOWN:
-            countdown_val = 1 + ((_RUN_COUNTDOWN_MS - self.run_countdown_elapsed_ms) // 1000)
-            self.draw_message(ctx, [str(countdown_val)], [(1,1,0)], twentyfour_pt)
-        elif self.current_state == STATE_RUN:
-            # convert current_power_duration to string, dividing all four values down by 655 (to get a value from 0-100)
-            current_power, _ = self.current_power_duration
-            power_str = str(tuple([x//655 for x in current_power]))
-            #TODO - remember the directon to be shown: direction_str = str(self.current_instruction.press_type)
-            self.draw_message(ctx, ["Running...",power_str], [(1,1,1),(1,1,0)], label_font_size)
-        elif self.current_state == STATE_DONE:
-            self.draw_message(ctx, ["Program","complete!","Replay:Press C","Restart:Press F"], [(0,1,0),(0,1,0),(1,1,0),(0,1,1)], label_font_size)
+        if self._refresh or self.notification is not None:
+            self._refresh = False
+            clear_background(ctx)   
+            ctx.save()
+            ctx.font_size = label_font_size
+            if self.current_state == STATE_LOGO:
+                draw_logo_animated(ctx, self.rpm, self._animation_counter, [self.b_msg, self.t_msg], self.qr_code)
+            # Scroll mode indicator
+            elif self.is_scroll:
+                ctx.rgb(0,0.2,0).rectangle(     -120,-120, 115+H_START,240).fill()
+                ctx.rgb(0,0  ,0).rectangle(H_START-5,-120,10-2*H_START,240).fill()
+                ctx.rgb(0,0.2,0).rectangle(5-H_START,-120, 115+H_START,240).fill()
+            else:
+               ctx.rgb(0,0,0).rectangle(-120,-120,240,240).fill()
+            # Main screen content 
+            if   self.current_state == STATE_WARNING:
+                self.draw_message(ctx, ["BadgeBot requires","HexDrive hexpansion","from RobotMad","github.com","/TeamRobotmad","/BadgeBot"], [(1,1,1),(1,1,0),(1,1,0),(1,1,1),(1,1,1),(1,1,1)], label_font_size)
+            elif self.current_state == STATE_REMOVED:
+                self.draw_message(ctx, ["HexDrive","removed","Please reinsert"], [(1,1,0),(1,1,1),(1,1,1)], label_font_size)      
+            elif self.current_state == STATE_DETECTED:
+                self.draw_message(ctx, ["Hexpansion","detected in",f"Slot {self.detected_port}","Init EEPROM","as HexDrive?"], [(1,1,1),(1,1,1),(0,0,1),(1,1,1),(1,1,0)], label_font_size)
+            elif self.current_state == STATE_ERASE:
+                self.draw_message(ctx, ["HexDrive","detected in",f"Slot {self.erase_port}","Erase","EEPROM?"], [(1,1,0),(1,1,1),(0,0,1),(1,0,0),(1,0,0)], label_font_size)             
+            elif self.current_state == STATE_UPGRADE:
+                self.draw_message(ctx, ["HexDrive","detected in",f"Slot {self.upgrade_port}","Upgrade","HexDrive app?"], [(1,1,0),(1,1,1),(0,0,1),(1,1,1),(1,1,1)], label_font_size)             
+            elif self.current_state == STATE_PROGRAMMING:
+                self.draw_message(ctx, ["HexDrive:","Programming","EEPROM","Please wait..."], [(1,1,0),(1,1,1),(1,1,1),(1,1,1)], label_font_size)            
+            elif self.current_state == STATE_HELP:                
+                self.draw_message(ctx, ["BadgeBot","To Program:","Press C","When finished:","Long press C"], [(1,1,0),(1,1,1),(1,1,1),(1,1,1),(1,1,1)], label_font_size)
+            elif self.current_state == STATE_ERROR:
+                self.draw_message(ctx, self.error_message, [(1,0,0)]*len(self.error_message), label_font_size)
+            elif self.current_state == STATE_MESSAGE:
+                self.draw_message(ctx, self.error_message, [(0,1,0)]*len(self.error_message), label_font_size)            
+            elif self.current_state == STATE_RECEIVE_INSTR:
+                # Display list of movements
+                for i_num, instr in enumerate(["START"] + self.instructions + [self.current_instruction, "END"]):
+                    # map the instruction to a colour & change language from up/down to fwd/rev
+                    colour = (1,1,1)
+                    if instr is not None:
+                        direction = str(instr).split()[0]
+                        print(direction)
+                        if   direction == "UP":
+                            instr = "FWD " + str(instr).split()[1]
+                            colour = (0,1,1)
+                        elif direction == "DOWN":
+                            instr = "REV " + str(instr).split()[1]
+                            colour = (1,0,1)
+                        elif direction == "LEFT":
+                            colour = (1,0,0)
+                        elif direction == "RIGHT":
+                            colour = (0,1,0)            
+                    ctx.rgb(*colour).move_to(H_START, V_START + label_font_size * (self.scroll_offset + i_num)).text(str(instr))
+            elif self.current_state == STATE_COUNTDOWN:
+                countdown_val = 1 + ((_RUN_COUNTDOWN_MS - self.run_countdown_elapsed_ms) // 1000)
+                self.draw_message(ctx, [str(countdown_val)], [(1,1,0)], twentyfour_pt)
+            elif self.current_state == STATE_RUN:
+                # convert current_power_duration to string, dividing all four values down by 655 (to get a value from 0-100)
+                current_power, _ = self.current_power_duration
+                power_str = str(tuple([x//655 for x in current_power]))
+                #TODO - remember the directon to be shown: direction_str = str(self.current_instruction.press_type)
+                self.draw_message(ctx, ["Running...",power_str], [(1,1,1),(1,1,0)], label_font_size)
+            elif self.current_state == STATE_DONE:
+                self.draw_message(ctx, ["Program","complete!","Replay:Press C","Restart:Press F"], [(0,1,0),(0,1,0),(1,1,0),(0,1,1)], label_font_size)
+            elif self.current_state == STATE_SERVO: 
+                servo_text    = ["S"]*5
+                servo_colours = [(0,0.4,0.4)]*5                         # Default - Cyan
+                servo_text[0] = "Servo Test:"
+                servo_colours[0] = (1,1,1)                              # Title - White
+                for i in range(4):
+                    if self.servo[i] is None or self.servo_mode[i] == 0:
+                        servo_colours[1+i] = (0.4,0,0)                  # Not activated - Red
+                    elif self.servo_mode[i] == 2:
+                        servo_colours[1+i] = (0.4,0.4,0)                # Scanning Mode - Yellow
+                    servo_text[i+1] = "Off" if (self.servo[i] is None or self.servo_mode[i] == 0) else f"{int(self.servo[i]):+7}"
+                # Selected Servo - Brighter
+                servo_colours[1+self.servo_selected] = tuple(int(j * 2.5) for j in servo_colours[1+self.servo_selected])                            
+                self.draw_message(ctx, servo_text, servo_colours, label_font_size)
+            ctx.restore()
+
+        # These need to be drawn every frame as they contain animations
+        if self.current_state == STATE_MENU:
+            clear_background(ctx)               
+            self.menu.draw(ctx)
+
         if self.notification:
             self.notification.draw(ctx)
-        ctx.restore()
 
 
     def clear_leds(self):
@@ -865,7 +1048,7 @@ class BadgeBotApp(app.App):
             tildagonos.leds[i] = (0, 0, 0)
 
 
-    def draw_message(self, ctx, message, colours, size):
+    def draw_message(self, ctx, message, colours, size=label_font_size):
         ctx.font_size = size
         num_lines = len(message)
         for i_num, instr in enumerate(message):
@@ -883,6 +1066,73 @@ class BadgeBotApp(app.App):
             ctx.rgb(*colour).move_to(-width//2, y_position).text(text_line)
 
 
+    def reset_servo(self):
+        if self.hexdrive_app is not None:
+            self.hexdrive_app.set_power(True)
+            # initialise the 4 servos
+            for i in range(4):
+                self.hexdrive_app.set_servocentre(i, self.servo_centre[i])
+                # ensure we start at the centre
+                if self.servo[i] is not None:
+                    self.servo[i] = 0
+                    self.hexdrive_app.set_servoposition(i, self.servo[i])
+                # ensure we start with a positive rate of change
+                self.servo_rate[i] = abs(self.servo_rate[i])
+            self.servo_selected = 0
+            # leave the servo modes as they are
+
+
+### MENU FUNCTIONALITY ###
+
+    def set_menu(self, menu_name: Literal["main"]):
+        if self.menu is not None:
+            self.menu._cleanup()
+        self.current_menu = menu_name
+        if menu_name == "main":
+            self.menu = Menu(
+                self,
+                _main_menu_items,
+                select_handler=self._main_menu_select_handler,
+                back_handler=self._menu_back_handler,
+                )
+        elif menu_name == "Settings":
+            self.menu = Menu(
+                self,
+                _settings_menu_items,
+                select_handler=self._settings_menu_select_handler,
+                back_handler=self._menu_back_handler,
+                )
+
+
+    def _main_menu_select_handler(self, item, idx):
+        if item == "Settings":
+            self.set_menu(item)
+        elif item == "Robot":
+            self.set_menu(None)
+            self.button_states.clear()
+            self._animation_counter = 0
+            self.current_state = STATE_HELP
+            self._refresh = True
+        elif item == "Servo Test":
+            self.set_menu(None)
+            self.button_states.clear()
+            self.reset_servo()
+            self.current_state = STATE_SERVO
+            self._refresh = True
+            self._auto_repeat = 0                
+
+
+    def _settings_menu_select_handler(self, item, idx):
+        print(f"Selected {item} at index {idx}")
+
+
+    def _menu_back_handler(self):
+        if self.current_menu == "main":
+            self.minimise()
+        # There are only two menus so this is the only other option    
+        self.set_menu("main")
+
+
 ### BADGEBOT DEMO FUNCTIONALITY ###
     def _handle_instruction_press(self, press_type: Button):
         if self.last_press == press_type:
@@ -892,10 +1142,19 @@ class BadgeBotApp(app.App):
             self.current_instruction = Instruction(press_type)
         self.last_press = press_type
 
-    def reset(self):
-        self.current_state = STATE_MENU
+
+    def _auto_repeat_check(self, delta) -> bool:                
+        self._auto_repeat += delta
+        if self._auto_repeat > _AUTO_REPEAT_MS:
+            self._auto_repeat = 0
+            return True
+        return False
+
+
+    def reset_robot(self):
+        self.current_state = STATE_HELP
         self.last_press = BUTTON_TYPES["CONFIRM"]
-        self.animation_counter = 0
+        self._animation_counter = 0
         self.long_press_delta = 0
         self.is_scroll = False
         self.scroll_offset = 0
@@ -936,13 +1195,6 @@ class BadgeBotApp(app.App):
             if len(self.instructions) >= 5:
                 self.scroll_offset -= 1
             self.current_instruction = None
-
-
-
-
-
-
-
 
 class Instruction:
     def __init__(self, press_type: Button) -> None:


### PR DESCRIPTION
Use Badge Menu feature to select between "Turtle/Logo" and "Servo Tester"

Only take over LEDs once doing the Instuction/Run phase of movements and when showing red/green for errors/warnings.

Servo Tester UI:
4 position values shown in red (off), cyan (position control), yellow (auto scanning)
Selected Servo shown brighter
Up/Down to select which Servo to modify
Left/Right: in position control - adjust position directly
Left/Right: in auto scanning - adjust rate of scan

Confirm Button: cycle Off - Position - Scanning
Notification to say which mode when changed

New style scroll mode indicator - bars at the side of the screen - more visible than the whole screen background. 

hexdrive.py supports turning all servos channels off in one call by use of channel = None

efficiency: track if we have changed anything that is potentially going to affect the display and only draw if we have