### PR TITLE
Improve readability and support 4 versions of HexDrive

### DIFF
--- a/hexdrive.py
+++ b/hexdrive.py
@@ -218,13 +218,17 @@ class HexDriveApp(app.App):
             if channel < 0 or channel >= 4:
                 return False            
             if abs(position) > 1000:
-                return False             
-            if _MAX_SERVO_FREQ < self.PWMOutput[int(channel)].freq():
-                # Ensure PWM frequency is suitable for use with Servos
-                # otherwise the pulse width will not be accepted
-                if self._logging:
-                    print(f"H:{self.config.port}:PWM[{channel}]:Force freq to {_DEFAULT_SERVO_FREQ}Hz for Servo")
-                self.PWMOutput[int(channel)].freq(_DEFAULT_SERVO_FREQ)
+                return False
+            try:             
+                if _MAX_SERVO_FREQ < self.PWMOutput[int(channel)].freq():
+                    # Ensure PWM frequency is suitable for use with Servos
+                    # otherwise the pulse width will not be accepted
+                    self.PWMOutput[int(channel)].freq(_DEFAULT_SERVO_FREQ)
+                    if self._logging:
+                        print(f"H:{self.config.port}:PWM[{channel}]:Force freq to {_DEFAULT_SERVO_FREQ}Hz for Servo")                    
+            except:
+                print(f"H:{self.config.port}:PWM[{channel}]:freq set to {_DEFAULT_SERVO_FREQ} failed")
+                return False
             # Scale servo position to PWM duty cycle (500-2500us)
             pulse_width = int(self._servo_centre_ns[channel] + (position * 1000))
             try:


### PR DESCRIPTION
Break down update and draw actions into their own functions for each state to improve readability.

When initialising HexDrive EEPROM allow user to select from 4 board types: 4 servo, 2 motor, 2 servo/1motor, unknown which have unique PIDs.
When finding a HexDrive by PID, accept any of the above and set num_servos and num_motors accordingly.
Only offer "Servo Test" if there is a Servo.
Only offer "Motor Moves" if there is a Motor.
Test Servo: UI for the right number of Servos - centred vertially.
Move Motors: Currently no functionality if only 1 motor - so you get a warning.  If we can come up with something to do with 1 motor this is place holder to do it.

NB 2 servo/1 motor is probably going to be of use with multiple bords fitted - either to deliver a pair of motors run from HexDrives on different sides of the Badge, or to support 3 motor use cases. (need to support multiple HexDrives being active for this.)

hexdrive.py: add try: around PWM function it was missing for which could fail.