### PR TITLE
Badge version 1.9.0 software compatibility

### DIFF
--- a/app.py
+++ b/app.py
@@ -222,6 +222,8 @@ class BadgeBotApp(app.App):
         self.num_motors   = 2       # Default assumed for a single HexDrive
 
         # Servo Tester
+        self._time_since_last_update = 0
+        self._keep_alive_period      = 500              # ms (half the value used in hexdrive.py)  
         self.num_servos   = 4       # Default assumed for a single HexDrive
         self.servo        = [None]*4                    # Servo Positions
         self.servo_centre = [_SERVO_DEFAULT_CENTRE]*4   # Trim Servo Centre
@@ -1185,8 +1187,14 @@ class BadgeBotApp(app.App):
                 else:
                     self._refresh = True
                 self.notification = Notification(f"  Servo {self.servo_selected}:\n {self._servo_modes[self.servo_mode[self.servo_selected]]}")
+        
+        self._time_since_last_update += delta
+        if self._time_since_last_update > self._keep_alive_period:
+            self._time_since_last_update = 0
+            self._refresh = True
 
         for i in range(self.num_servos):
+            _refresh = self._refreah
             if self.servo_mode[i] == 3:
                 # for any servo set to Scan mode, update the position
                 if self.servo[self.servo_selected] is None:
@@ -1200,8 +1208,8 @@ class BadgeBotApp(app.App):
                     # swap direction
                     self.servo_rate[i] = -self.servo_rate[i]
                     self.servo[i] = -self.servo_range[i] - (self.servo_centre[i] - _SERVO_DEFAULT_CENTRE)
-                self._refresh = True
-            if self._refresh and self.hexdrive_app is not None and self.servo_mode[i] != 0 and self.servo[i] is not None:
+                _refresh = True
+            if _refresh and self.hexdrive_app is not None and self.servo_mode[i] != 0 and self.servo[i] is not None:
                 # scanning servo or the selected servo
                 self.hexdrive_app.set_servoposition(i, int(self.servo[i]))
 
@@ -1472,6 +1480,8 @@ class BadgeBotApp(app.App):
                     self.hexdrive_app.set_servoposition(i, int(self.servo[i]))
             # leave the servo modes as they are
         self.servo_selected = 0
+        self._time_since_last_update = 0
+
 
 
 ### MENU FUNCTIONALITY ###

--- a/app.py
+++ b/app.py
@@ -26,7 +26,7 @@ from tildagonos import tildagonos
 
 import app
 
-from .utils import chain, draw_logo_animated
+from .utils import chain, draw_logo_animated, parse_version
 
 # Hard coded to talk to EEPROMs on address 0x50 - because we know that is what is on the HexDrive Hexpansion
 # makes it a lot more efficient than scanning the I2C bus for devices and working out what they are

--- a/app.py
+++ b/app.py
@@ -1194,7 +1194,7 @@ class BadgeBotApp(app.App):
             self._refresh = True
 
         for i in range(self.num_servos):
-            _refresh = self._refreah
+            _refresh = self._refresh
             if self.servo_mode[i] == 3:
                 # for any servo set to Scan mode, update the position
                 if self.servo[self.servo_selected] is None:

--- a/app.py
+++ b/app.py
@@ -238,7 +238,6 @@ class BadgeBotApp(app.App):
 
         eventbus.on_async(RequestForegroundPushEvent, self._gain_focus, self)
         eventbus.on_async(RequestForegroundPopEvent, self._lose_focus, self)
-        #eventbus.on_async(ButtonUpEvent, self._handle_button_up, self)
 
         # We start with focus on launch, without an event emmited
         self._gain_focus(RequestForegroundPushEvent(self))
@@ -358,9 +357,6 @@ class BadgeBotApp(app.App):
         if port not in range(1, 7):
             return False
         try:
-            #i2c = I2C(port)
-            #i2c.writeto(_EEPROM_ADDR, bytes([0]*_EEPROM_NUM_ADDRESS_BYTES))  # Read header @ address 0                
-            #header_bytes = i2c.readfrom(_EEPROM_ADDR, 32)
             header_bytes = I2C(port).readfrom_mem(_EEPROM_ADDR, 0, 32, addrsize = (8*_EEPROM_NUM_ADDRESS_BYTES))
         except OSError:
             # no EEPROM on this port
@@ -497,8 +493,6 @@ class BadgeBotApp(app.App):
             finally:
                 time.sleep_ms(1)
         try:
-            #i2c.writeto(addr, bytes([0]*_EEPROM_NUM_ADDRESS_BYTES))  # Read header @ address 0                
-            #header_bytes = i2c.readfrom(addr, 32)
             header_bytes = i2c.readfrom_mem(addr, 0, 32, addrsize = (8*_EEPROM_NUM_ADDRESS_BYTES))
         except Exception as e:
             print(f"H:Error reading header back: {e}")
@@ -572,8 +566,6 @@ class BadgeBotApp(app.App):
                 if port is None:
                     return None
                 i2c = I2C(port)
-            #i2c.writeto(_EEPROM_ADDR, bytes([0]*_EEPROM_NUM_ADDRESS_BYTES))  # Read header @ address 0                
-            #header_bytes = i2c.readfrom(_EEPROM_ADDR, 32)
             header_bytes = i2c.readfrom_mem(_EEPROM_ADDR, 0, 32, addrsize = (8*_EEPROM_NUM_ADDRESS_BYTES))
             return HexpansionHeader.from_bytes(header_bytes)
         except OSError:     

--- a/app.py
+++ b/app.py
@@ -1491,7 +1491,13 @@ class BadgeBotApp(app.App):
         if self._settings['logging'].v:
             print(f"H:Set Menu {menu_name}")
         if self.menu is not None:
-            self.menu._cleanup()
+            try:
+                self.menu._cleanup()
+            except:
+                # See badge-2024-software PR#168
+                # in case badge s/w changes and this is done within the menu s/w
+                # and then access to this function is removed
+                pass
         self.current_menu = menu_name
         if menu_name == "main":
             # construct the main menu based on template

--- a/app.py
+++ b/app.py
@@ -1263,7 +1263,9 @@ class BadgeBotApp(app.App):
             clear_background(ctx)   
             ctx.save()
             ctx.font_size = label_font_size
-            ctx.text_align = ctx.LEFT
+            if ctx.text_align != ctx.LEFT:             
+                print(f"H:Font alignment {ctx.text_align}!")
+                ctx.text_align = ctx.LEFT
             ctx.text_baseline = ctx.BOTTOM            
             if self.current_state == STATE_LOGO:
                 draw_logo_animated(ctx, self.rpm, self._animation_counter, [self.b_msg, self.t_msg], self.qr_code)

--- a/app.py
+++ b/app.py
@@ -357,9 +357,10 @@ class BadgeBotApp(app.App):
         if port not in range(1, 7):
             return False
         try:
-            i2c = I2C(port)
-            i2c.writeto(_EEPROM_ADDR, bytes([0]*_EEPROM_NUM_ADDRESS_BYTES))  # Read header @ address 0                
-            header_bytes = i2c.readfrom(_EEPROM_ADDR, 32)
+            #i2c = I2C(port)
+            #i2c.writeto(_EEPROM_ADDR, bytes([0]*_EEPROM_NUM_ADDRESS_BYTES))  # Read header @ address 0                
+            #header_bytes = i2c.readfrom(_EEPROM_ADDR, 32)
+            header_bytes = I2C(port).readfrom_mem(_EEPROM_ADDR, 0, 32, addrsize = (8*_EEPROM_NUM_ADDRESS_BYTES))
         except OSError:
             # no EEPROM on this port
             return False
@@ -496,8 +497,9 @@ class BadgeBotApp(app.App):
             finally:
                 time.sleep_ms(1)
         try:
-            i2c.writeto(addr, bytes([0]*_EEPROM_NUM_ADDRESS_BYTES))  # Read header @ address 0                
-            header_bytes = i2c.readfrom(addr, 32)
+            #i2c.writeto(addr, bytes([0]*_EEPROM_NUM_ADDRESS_BYTES))  # Read header @ address 0                
+            #header_bytes = i2c.readfrom(addr, 32)
+            header_bytes = i2c.readfrom_mem(addr, 0, 32, addrsize = (8*_EEPROM_NUM_ADDRESS_BYTES))
         except Exception as e:
             print(f"H:Error reading header back: {e}")
             return False
@@ -526,10 +528,19 @@ class BadgeBotApp(app.App):
             vfs.mount(partition, mountpoint, readonly=False)
             if self._settings['logging'].v:
                 print("H:EEPROM initialised")
+        except OSError as e:
+            if e.args[0] == 1:
+                #already_mounted
+                if self._settings['logging'].v:
+                    print("H:EEPROM initialised")                
+            else:
+                print(f"H:Error mounting: {e}")
+                return False
         except Exception as e:
-            print(f"H:Error mounting: {e}")
+            print(f"H:Error mounting: {e}")                
             return False
         return True 
+
 
     def erase_eeprom(self, port, addr) -> bool:
         if self._settings['logging'].v:
@@ -561,8 +572,9 @@ class BadgeBotApp(app.App):
                 if port is None:
                     return None
                 i2c = I2C(port)
-            i2c.writeto(_EEPROM_ADDR, bytes([0]*_EEPROM_NUM_ADDRESS_BYTES))  # Read header @ address 0                
-            header_bytes = i2c.readfrom(_EEPROM_ADDR, 32)
+            #i2c.writeto(_EEPROM_ADDR, bytes([0]*_EEPROM_NUM_ADDRESS_BYTES))  # Read header @ address 0                
+            #header_bytes = i2c.readfrom(_EEPROM_ADDR, 32)
+            header_bytes = i2c.readfrom_mem(_EEPROM_ADDR, 0, 32, addrsize = (8*_EEPROM_NUM_ADDRESS_BYTES))
             return HexpansionHeader.from_bytes(header_bytes)
         except OSError:     
             return None   

--- a/app.py
+++ b/app.py
@@ -627,15 +627,7 @@ class BadgeBotApp(app.App):
                 # There are currently no possible HexDrives plugged in
                 self._animation_counter = 0
                 self.current_state = STATE_WARNING
-            else:
-            try:
-
-                    self.error_message = ["Please update","Hexdrive(s)","before updating","badge OTA"]
-                    self.current_state = STATE_MESSAGE                                     
-                    if self._settings['logging'].v:
-                        print(f"H:HexDrive on port {self.upgrade_port} upgraded please reboop")                    
-            except:
-                pass                
+            else:      
                 self.current_state = STATE_CHECK
             return
         

--- a/app.py
+++ b/app.py
@@ -1285,7 +1285,7 @@ class BadgeBotApp(app.App):
             elif self.current_state == STATE_RUN:
                 # convert current_power_duration to string, dividing all four values down by 655 (to get a value from 0-100)
                 current_power, _ = self.current_power_duration
-                power_str = str(tuple([max(-100, x//(self._settings['max_power']//100) for x in current_power]))
+                power_str = str(tuple([max(-100, x//(self._settings['max_power']//100)) for x in current_power]))
                 self.draw_message(ctx, ["Running...",power_str], [(1,1,1),(1,1,0)], label_font_size)
             elif self.current_state == STATE_DONE:
                 #self.draw_message(ctx, ["Program","complete!","Replay:Press C","Restart:Press F"], [(0,1,0),(0,1,0),(1,1,0),(0,1,1)], label_font_size)

--- a/hexdrive.py
+++ b/hexdrive.py
@@ -3,8 +3,8 @@
 # It is then run from the EEPROM by the BadgeOS.
 
 import asyncio
-
-from machine import I2C, PWM
+import ota
+from machine import I2C, PWM, Pin
 from system.eventbus import eventbus
 from system.scheduler.events import RequestStopAppEvent
 
@@ -21,101 +21,181 @@ _DEFAULT_PWM_FREQ = 20000
 _DEFAULT_SERVO_FREQ = 50            # 20mS period
 _MAX_SERVO_FREQ = 200               # 5mS period (can work with some Servos but not all)
 _DEFAULT_KEEP_ALIVE_PERIOD = 1000   # 1 second
-_SERVO_CENTRE_NS = 1500000          # 1500us
+_SERVO_CENTRE    = 1500             # 1500us
+_MAX_SERVO_RANGE = 1400             # 1400us either side of centre (VERY WIDE)
+_SERVO_MAX_TRIM  = 1000             # us
 
+_EEPROM_ADDR  = 0x50
+_EEPROM_NUM_ADDRESS_BYTES = 2
+_PID_ADDR     = 0x12
 _SYSTEM_I2C_BUS = 7
 
 class HexDriveApp(app.App):
 
     def __init__(self, config=None):
-        self.config = config
+        super().__init__()
+        self.config = config        
         self._logging = True
-        self.keep_alive_period = _DEFAULT_KEEP_ALIVE_PERIOD
-        self.power_state = None
-        self.pwm_setup_failed = True
-        self.time_since_last_update = 0
-        self.outputs_energised = False
+        self._HEXDRIVE_TYPES = [HexDriveType(0xCB, motors=2, servos=4), 
+                                HexDriveType(0xCA, motors=2, name="2 Motor"), 
+                                HexDriveType(0xCC, servos=4, name="4 Servo"), 
+                                HexDriveType(0xCD, motors=1, servos=2, name = "1 Mot 2 Srvo")]
+        self._hexdrive_type_index = None
+        self._use_custom_ls_pin_functions = True
+        self._keep_alive_period = _DEFAULT_KEEP_ALIVE_PERIOD
+        self._power_state = None
+        self._pwm_setup_failed = True
+        self._time_since_last_update = 0
+        self._outputs_energised = False
         self.PWMOutput = [None] * 4
-        self.power_detect = self.config.ls_pin[_DETECT_PIN]
-        self.power_control = self.config.ls_pin[_ENABLE_PIN]       
-        self._servo_centre_ns = [_SERVO_CENTRE_NS] * 4
+        self._freq = [0] * 4
+        self._motor_output  = [0] * 2
+        if config is None:
+            print("H:No Config!")
+            return        
+        self._power_detect  = self.config.ls_pin[_DETECT_PIN]
+        self._power_control = self.config.ls_pin[_ENABLE_PIN]  
+        self._servo_centre = [_SERVO_CENTRE] * 4
         eventbus.on_async(RequestStopAppEvent, self._handle_stop_app, self)
-
+        try:
+            ver = self._parse_version(ota.get_version())
+            print(f"H:S/W {ver}")
+            # e.g. v1.9.0-beta.1
+            if ver >= [1, 9, 0]:
+                self._use_custom_ls_pin_functions = False
+        except Exception as e:
+            print(f"H:Ver check failed {e}")
         self.initialise()
 
+
     def initialise(self) -> bool:
-        self.pwm_setup_failed = True
+        self._pwm_setup_failed = True
         if self.config is None:
             return False        
         # report app starting and which port it is running on
-        print(f"HexDrive V{APP_VERSION} by RobotMad on port {self.config.port}")
-        # Set Power Detect Pin to Input and Power Enable Pin to Output
-        self._set_pin_direction(self.power_detect.pin,  1)  # input
-        self._set_pin_direction(self.power_control.pin, 0)  # output
+        print(f"H:HexDrive V{APP_VERSION} by RobotMad on port {self.config.port}")
+        # LS Pins
+        if self._use_custom_ls_pin_functions:
+            try:
+                # Badge s/w changes can break even the simplest of things so we need to be prepared
+                # Set Power Detect Pin to Input and Power Enable Pin to Output
+                self._set_pin_direction(self._power_detect.pin,  1)  # input
+                self._set_pin_direction(self._power_control.pin, 0)  # output
+            except Exception as e:
+                print(f"H:{self.config.port}:Legacy ls_pin setup failed {e}")
+                # as old method failed we will try the new method
+                self._use_custom_ls_pin_functions = False
+        if  not self._use_custom_ls_pin_functions:
+            # Try to use v1.9.0+ method of setting up pins
+            try:
+                self._power_detect.init(mode=Pin.IN)
+                self._power_control.init(mode=Pin.OUT)
+            except Exception as e:
+                print(f"H:{self.config.port}:Direct ls_pin setup failed {e}")
+                return False
         self.set_power(False)
-        # Set all HexDrive Hexpansion HS pins to low level outputs
-        for hs_pin in self.config.pin:
-            hs_pin.value(0)    
-        if self.config.pin is not None and len(self.config.pin) == 4:
+    
+        # read hexpansion header from EEPROM to find out which type we are
+        # and allocate PWM outputs accordingly
+        self._hexdrive_type_index = self._check_port_for_hexdrive(self.config.port)
+        if self._logging and self._hexdrive_type_index is not None:
+            print(f"H:{self.config.port}:Type:'{self._HEXDRIVE_TYPES[self._hexdrive_type_index].name}'")
+
+        # HS Pins
+        if self.config.pin is not None and len(self.config.pin) == 4:             
             # Allocate PWM generation to pins
             for channel, hs_pin in enumerate(self.config.pin):
-                try:
-                    self.PWMOutput[channel] = PWM(hs_pin, freq = _DEFAULT_PWM_FREQ, duty_u16 = 0)
-                    if self._logging:
-                        print(f"H:{self.config.port}:PWM[{channel}]:{self.PWMOutput[channel]}")
-                except:
-                    # There are a finite number of PWM resources so it is possible that we run out
-                    print(f"H:{self.config.port}:PWM[{channel}]: allocation failed")
-                    return False
-            self.pwm_setup_failed = False
-        return not self.pwm_setup_failed
+                self._freq[channel] = 0
+                try:    
+                    # Set HexDrive Hexpansion HS pins to low level outputs
+                    hs_pin.init(mode=Pin.OUT)
+                    hs_pin.value(0)
+                except Exception as e:
+                    #print(f"H:{self.config.port}:hs pin setup failed {e}")
+                    return False                  
+                if self._hexdrive_type_index is not None:
+                    if channel < (2 * self._HEXDRIVE_TYPES[self._hexdrive_type_index].motors):
+                        # First channels are for motors (can be 0, 1 or 2 motors)
+                        if 0 == channel % 2:
+                            # initialise motor PWM output on even channel
+                            self._motor_output[(channel>>1)] = 0
+                            self._freq[channel] = _DEFAULT_PWM_FREQ
+                            #print(f"H:{self.config.port}:Motor PWM[{channel}]")
+                        else:
+                            # ignore the motor PWM output on odd channel - we will switch it on when needed
+                            pass
+                    else:
+                        # Remaining channels are for servos (can be 4, 2 or 0 servos
+                        self._freq[channel] = _DEFAULT_SERVO_FREQ
+                        #print(f"H:{self.config.port}:Servo PWM[{channel}]")
+                if 0 < self._freq[channel]:        
+                    try:
+                        self.PWMOutput[channel] = PWM(hs_pin, freq = self._freq[channel], duty_u16 = 0)
+                        if self._logging:
+                            print(f"H:{self.config.port}:PWM[{channel}]:{self.PWMOutput[channel]}")
+                    except Exception as e:
+                        # There are a finite number of PWM resources so it is possible that we run out
+                        print(f"H:{self.config.port}:PWM[{channel}]:PWM(init) failed {e}")
+                        return False
+            self._pwm_setup_failed = False
+        return not self._pwm_setup_failed
 
 
     def deinitialise(self) -> bool:
         # Turn off all PWM outputs & release resources
-        for channel, pwm in enumerate(self.PWMOutput):
-            pwm.deinit()
-            self.PWMOutput[channel] = None
         self.set_power(False)
+        for channel, pwm in enumerate(self.PWMOutput):
+            try:
+                pwm.deinit()    
+            except:
+                pass
+            self.PWMOutput[channel] = None
+            self._freq[channel] = 0
+            self._motor_output[(channel>>1)] = 0            
         for hs_pin in self.config.pin:
-            hs_pin.value(0)          
+            hs_pin.init(mode=Pin.OUT)
+            hs_pin.value(0)                  
         return True
 
 
     # Handle the RequestStopAppEvent so that ew can release resources
     async def _handle_stop_app(self, event):
-        if event.app == self:
-            if self._logging:
-                print(f"H:{self.config.port}:Stopping HexDrive App & Releasing PWM resources")
-            self.deinitialise()
+        try:
+            if event.app == self:
+                if self._logging:
+                    print(f"H:{self.config.port}:Stop")
+                self.deinitialise()
+        except:
+            pass      
 
 
     # Check keep alive period and turn off PWM outputs if exceeded
     def background_update(self, delta):
-        if (self.config is None) or self.pwm_setup_failed:
+        if (self.config is None) or self._pwm_setup_failed:
             return
-        self.time_since_last_update += delta
-        if self.time_since_last_update > self.keep_alive_period:
-            self.time_since_last_update = 0
+        self._time_since_last_update += delta
+        if self._time_since_last_update > self._keep_alive_period:
+            self._time_since_last_update = 0
             for pwm in enumerate(self.PWMOutput):
                 try:
                     pwm.duty_u16(0)
                 except:
                     pass
-            if self.outputs_energised:
-                self.outputs_energised = False
+            if self._outputs_energised:
+                self._outputs_energised = False
                 # First time the keep alive period has expired so report it
                 if self._logging:
-                    print(f"H:{self.config.port}:Keep Alive Timeout")            
+                    print(f"H:{self.config.port}:Timeout")            
             # we keep retriggering in case anything else has corrupted the PWM outputs
 
 
     def get_version(self) -> int:
         return APP_VERSION
     
+
     # Get the current status of the HexDrive App
     def get_status(self) -> bool:
-        return not self.pwm_setup_failed
+        return not self._pwm_setup_failed
 
 
     # Set the logging state
@@ -132,56 +212,83 @@ class HexDriveApp(app.App):
     # Just because the SPMSU is turned off does not mean that the outputs are NOT energised
     # as there could be external battery power
     def set_power(self, state) -> bool:
-        if (self.config is None) or (state == self.power_state):
+        if (self.config is None) or (state == self._power_state):
             return False
         if self._logging:
             print(f"H:{self.config.port}:Power={'On' if state else 'Off'}")
         if self.get_booster_power():
             # if the power detect pin is high then the SMPSU has a power source so enable it
-            self._set_pin_state(self.power_control.pin, state)
-            self._set_pin_direction(self.power_control.pin, 0)  # in case it gets corrupted by other code
-        self.power_state = state
-        return self.power_state    
+            if self._use_custom_ls_pin_functions:
+                try:
+                    self._set_pin_state(self._power_control.pin, state)
+                    self._set_pin_direction(self._power_control.pin, 0)  # in case it gets corrupted by other code
+                except Exception as e:
+                    print(f"H:{self.config.port}:Legacy power control failed {e}")
+                    return False
+            else:
+                try:
+                    self._power_control.init(mode=Pin.OUT)
+                    self._power_control.value(state)
+                except Exception as e:
+                    print(f"H:{self.config.port}:Direct power control failed {e}")
+                    return False    
+        self._power_state = state
+        return self._power_state    
 
 
     # Get the current state of the SMPSU enable pin
     def get_power(self) -> bool:
-        return self.power_state
+        return self._power_state
 
 
     # Get the current state of the SMPSU power source
     def get_booster_power(self) -> bool:
-        return self._get_pin_state(self.power_detect.pin)
+        if self._use_custom_ls_pin_functions:
+            try:
+                return self._get_pin_state(self._power_detect.pin)
+            except Exception as e:
+                print(f"H:{self.config.port}:Legacy power detect failed {e}")
+                return False
+        else:
+            try:
+                return self._power_detect.value()
+            except Exception as e:
+                print(f"H:{self.config.port}:Direct power detect failed {e}")
+                return False
 
 
-    # Set the keep alive period - this is the time in milli-seconds that the PWM outputs will be kept on
     def set_keep_alive(self, period):
-        self.keep_alive_period = period
+        self._keep_alive_period = period
 
     
-    # Only one PWM frequency (in Hz) is supported for all outputs due to timer limitations
     # Use 50 to 200 for Servos and 5000 to 20000 for motors
-    def set_freq(self, freq) -> bool:
-        if self.pwm_setup_failed:
+    def set_freq(self, freq, channel=None) -> bool:
+        if self._pwm_setup_failed:
             return False
-        for channel, pwm in enumerate(self.PWMOutput):
-            try:
-                pwm.freq(int(freq))
-                if self._logging:
-                    print(f"H:{self.config.port}:PWM[{channel}] freq: {int(freq)}Hz")
-            except:
-                print(f"H:{self.config.port}:PWM[{channel}] freq: set {int(freq)}Hz failed")
-                return False
+        for this_channel, pwm in enumerate(self.PWMOutput):
+            if channel is None or this_channel == channel:
+                try:
+                    pwm.freq(int(freq))
+                    if self._logging:
+                        print(f"H:{self.config.port}:PWM[{channel}]:{int(freq)}Hz")
+                except Exception as e:
+                    print(f"H:{self.config.port}:PWM[{channel}]:set freq failed {e}")
+                    return False
+                self._freq[this_channel] = int(freq)
         return True
     
 
     # Get the current PWM frequency for a specific output
     def get_freq(self, channel=0) -> int:
-        if self.pwm_setup_failed:
+        if self._pwm_setup_failed:
             return 0
         if channel < 0 or channel >= 4:
             return 0
-        return self.PWMOutput[int(channel)].freq()
+        try:
+            f = self.PWMOutput[int(channel)].freq()
+        except:
+            f = 0
+        return f
     
 
     # set the pulse width for a specific servo output
@@ -191,7 +298,7 @@ class HexDriveApp(app.App):
     # This is a very wide range and may not be suitable for all servos, some will 
     # only be happy with 1000-2000us (i.e. position in the range -500 to 500)
     def set_servoposition(self, channel=None, position=None) -> bool:
-        if self.pwm_setup_failed:
+        if self._pwm_setup_failed:
             return False
         if position is None:
             # position == None -> Turn off PWM (some servos will then turn off, others will stay in last position)
@@ -203,7 +310,8 @@ class HexDriveApp(app.App):
                     except:
                         pass
                 if self._logging:
-                    print(f"H:{self.config.port}:PWM:All Off")
+                    print(f"H:{self.config.port}:PWM:[All]:Off")
+                self._outputs_energised = False
                 return True
             elif channel < 0 or channel >= 4:
                 return False
@@ -211,90 +319,126 @@ class HexDriveApp(app.App):
                 self.PWMOutput[int(channel)].duty_ns(0)
                 if self._logging:
                     print(f"H:{self.config.port}:PWM[{int(channel)}]:Off")
-            except:
-                print(f"H:{self.config.port}:PWM[{int(channel)}]:Off failed")
-                return False            
+            except Exception as e:
+                print(f"H:{self.config.port}:PWM[{int(channel)}]:Off failed {e}")
+                return False
+            # check if all channels are now off and set outputs_energised accordingly
+            self._check_outputs_energised()          
         else:           
             if channel < 0 or channel >= 4:
                 return False            
-            if abs(position) > 1000:
+            if abs(position) > _MAX_SERVO_RANGE:
                 return False
+            self._outputs_energised = True
             try:             
                 if _MAX_SERVO_FREQ < self.PWMOutput[int(channel)].freq():
                     # Ensure PWM frequency is suitable for use with Servos
                     # otherwise the pulse width will not be accepted
                     self.PWMOutput[int(channel)].freq(_DEFAULT_SERVO_FREQ)
                     if self._logging:
-                        print(f"H:{self.config.port}:PWM[{channel}]:Force freq to {_DEFAULT_SERVO_FREQ}Hz for Servo")                    
-            except:
-                print(f"H:{self.config.port}:PWM[{channel}]:freq set to {_DEFAULT_SERVO_FREQ} failed")
+                        print(f"H:{self.config.port}:PWM[{channel}]:{_DEFAULT_SERVO_FREQ}Hz for Servo")                    
+            except Exception as e:
+                print(f"H:{self.config.port}:PWM[{channel}]:set freq failed {e}")
                 return False
             # Scale servo position to PWM duty cycle (500-2500us)
-            pulse_width = int(self._servo_centre_ns[channel] + (position * 1000))
+            pulse_width = int((self._servo_centre[channel] + position) * 1000)
             try:
                 if pulse_width != self.PWMOutput[int(channel)].duty_ns():
                     self.PWMOutput[int(channel)].duty_ns(pulse_width)
                     if self._logging:
                         print(f"H:{self.config.port}:PWM[{int(channel)}]:{pulse_width//1000}us")
-            except:
-                print(f"H:{self.config.port}:PWM[{int(channel)}]:{position} set failed")
+            except Exception as e:
+                print(f"H:{self.config.port}:PWM[{int(channel)}]:set pwm failed {e}")
                 return False
-        self.time_since_last_update = 0
+        self._time_since_last_update = 0
         return True
+
 
     # Set the centre position for a specific servo output
     # Note this does not change the current position of the servo
     # it will only affect the position next time it is set
     # you can use this to trim the centre position of the servo
     def set_servocentre(self, centre, channel=None) -> bool:
-        if self.pwm_setup_failed:
+        if self._pwm_setup_failed:
             return False
         if channel is not None and (channel < 0 or channel >= 4):
             return False
-        if centre < 500 or centre > 2500:
+        if centre < (_SERVO_CENTRE - _SERVO_MAX_TRIM ) or centre > (_SERVO_CENTRE + _SERVO_MAX_TRIM): 
             return False
         if channel is None:
-            self._servo_centre_ns = [int(centre * 1000)] * 4
+            self._servo_centre = [int(centre)] * 4
         else:    
-            self._servo_centre_ns[int(channel)] = int(centre * 1000)
+            self._servo_centre[int(channel)] = int(centre)
         return True
     
 
     # Set pairs of PWM duty cycles in one go using a signed value per motor channel (0-65535)
     def set_motors(self, outputs) -> bool:
-        if self.pwm_setup_failed:
+        if self._pwm_setup_failed:
             return False
-        self.outputs_energised = any(outputs)
+        self._outputs_energised = any(outputs)
         for motor, output in enumerate(outputs):
             if abs(output) > 65535:
                 return False
-            pwmA =  int(output) if output > 0 else 0
-            pwmB = -int(output) if output < 0 else 0
-            if not self._set_pwmoutput(motor<<1, pwmA) or not self._set_pwmoutput((motor<<1)+1, pwmB):
-                return False
-        self.time_since_last_update = 0
+            if output >= 0:
+                if 0 > self._motor_output[motor]:
+                    # switch which signal is being driven as the PWM output
+                    self.PWMOutput[(motor<<1)+1].deinit()
+                    self.config.pin[(motor<<1)+1].value(0)
+                    self.PWMOutput[(motor<<1)] = PWM(self.config.pin[(motor<<1)], freq = self._freq[(motor<<1)], duty_u16 = int(output))
+                self._set_pwmoutput((motor<<1), int(output))
+            else:
+                if 0 <= self._motor_output[motor]:
+                    # switch which signal is being driven as the PWM output
+                    self.PWMOutput[(motor<<1)].deinit()
+                    self.config.pin[(motor<<1)].value(0)
+                    self.PWMOutput[(motor<<1)+1] = PWM(self.config.pin[(motor<<1)+1], freq = self._freq[(motor<<1)], duty_u16 = -int(output))
+                self._set_pwmoutput((motor<<1)+1, -int(output))    
+            self._motor_output[motor] = output
+        self._check_outputs_energised()            
+        self._time_since_last_update = 0
         return True
 
 
     # Set all 4 PWM duty cycles in one go using a tuple (0-65535)
     def set_pwm(self, duty_cycles) -> bool:
-        if self.pwm_setup_failed:
+        if self._pwm_setup_failed:
             return False
-        self.outputs_energised = any(duty_cycles)
+        self._outputs_energised = any(duty_cycles)
         for channel, duty_cycle in enumerate(duty_cycles): 
             if not self._set_pwmoutput(channel, int(duty_cycle)):
                 return False
-        self.time_since_last_update = 0
+        self._time_since_last_update = 0
         return True
 
 
     # Get the current PWM duty cycle for a specific output (0-65535)
     def get_pwm(self, channel=0) -> int:
-        if self.pwm_setup_failed:
+        if self._pwm_setup_failed:
             return 0
         if channel >= len(self.PWMOutput):
             return 0
-        return self.PWMOutput[channel].duty_u16()
+        try:
+            pwm = self.PWMOutput[channel].duty_u16()
+        except:
+            pwm = 0
+        return pwm
+
+
+    # are any of the PWM outputs energised?
+    def _check_outputs_energised(self):
+        energised_output = False
+        for channel in self.PWMOutput:
+            try:
+                if 0 < channel.duty_ns():
+                    energised_output = True
+                    break
+            except:
+                pass
+        if self._outputs_energised != energised_output:
+            if self._logging:
+                print(f"H:{self.config.port}:Outputs {'Energised' if energised_output else 'De-energised'}")
+            self._outputs_energised = energised_output  
 
 
     # Set a single PWM duty cycle (0-65535) for a specific output
@@ -306,14 +450,57 @@ class HexDriveApp(app.App):
                 self.PWMOutput[channel].duty_u16(duty_cycle)
                 if self._logging:
                     print(f"H:{self.config.port}:PWM[{channel}]:{duty_cycle}")
-        except:
-            print(f"H:{self.config.port}:PWM[{channel}]:set {duty_cycle} failed")
+        except Exception as e:
+            print(f"H:{self.config.port}:PWM[{channel}]:set {duty_cycle} failed {e}")
             return False
         return True
 
 
+    def _check_port_for_hexdrive(self, port) -> int:
+        #just read the part of the header which contains the PID
+        try:
+            self.config.i2c.writeto(_EEPROM_ADDR, bytes([_PID_ADDR >> 8, _PID_ADDR & 0xFF]))
+            pid_bytes = self.config.i2c.readfrom(_EEPROM_ADDR, 2)
+        except OSError as e:
+            # no EEPROM on this port
+            print(f"H:{port}:EEPROM error: {e}")
+            return None
+        # check the MSByte of PID for HexDrive Family
+        if pid_bytes[1] != 0xCB:
+            return None
+        # check if this is a HexDrive header by scanning the _HEXDRIVE_TYPES list
+        for index, hexpansion_type in enumerate(self._HEXDRIVE_TYPES):
+            if pid_bytes[0] == hexpansion_type.pid_byte:
+                return index
+        # we are not interested in this type of hexpansion
+        return None
+    
+
+    def _parse_version(self, version):
+        #pre_components = ["final"]
+        #build_components = ["0", "000000z"]
+        #build = ""
+        components = []
+        if "+" in version:
+            version, build = version.split("+", 1)
+        #    build_components = build.split(".")
+        if "-" in version:
+            version, pre_release = version.split("-", 1)
+        #    if pre_release.startswith("rc"):
+        #        # Re-write rc as c, to support a1, b1, rc1, final ordering
+        #        pre_release = pre_release[1:]
+        #    pre_components = pre_release.split(".")
+        version = version.strip("v").split(".")
+        components = [int(item) if item.isdigit() else item for item in version]
+        #components.append([int(item) if item.isdigit() else item for item in pre_components])
+        #components.append([int(item) if item.isdigit() else item for item in build_components])
+        return components
+
+
+    ### Legacy LS Pin functions for use with BadgeOS < v1.9.0 ###
+
     # Set the state of a specific LS output pin
-    def _set_pin_state(self, pin, state):
+    def _set_pin_state(self, pin, state) -> bool:
         try:
             i2c = I2C(_SYSTEM_I2C_BUS)
             output_reg = i2c.readfrom_mem(pin[0], 0x02+pin[1], 1)[0]
@@ -321,9 +508,10 @@ class HexDriveApp(app.App):
             i2c.writeto_mem(pin[0], 0x02+pin[1], bytes([output_reg]))
             #if self._logging:
             #    print(f"H:{self.config.port}:Write to {hex(pin[0])} address {hex(0x02+pin[1])} value {hex(output_reg)}")
+            return True
         except Exception as e:
-            print(f"H:{self.config.port}:access to I2C(7) failed: {e}")
-
+            #print(f"H:{self.config.port}: {e}")
+            return False
 
     # Get the state of a specific LS input pin
     def _get_pin_state(self, pin) -> bool:
@@ -332,12 +520,12 @@ class HexDriveApp(app.App):
             input_reg = i2c.readfrom_mem(pin[0], 0x00+pin[1], 1)[0]
             return (input_reg & pin[2]) != 0
         except Exception as e:
-            print(f"H:{self.config.port}:access to I2C(7) failed: {e}")
+            #print(f"H:{self.config.port}: {e}")
             return False
 
 
     # Set the direction of a specific LS pin
-    def _set_pin_direction(self, pin, direction):
+    def _set_pin_direction(self, pin, direction) -> bool:
         try:
             # Use a Try in case access to i2C(7) is blocked for apps in future
             # presumably if this happens then the code will have been updated to
@@ -348,7 +536,18 @@ class HexDriveApp(app.App):
             i2c.writeto_mem(pin[0], 0x04+pin[1], bytes([config_reg]))
             #if self._logging:
             #    print(f"H:{self.config.port}:Write to {hex(pin[0])} address {hex(0x04+pin[1])} value {hex(config_reg)}")
+            return True
         except Exception as e:
-            print(f"H:{self.config.port}:access to I2C(7) failed: {e}")
+            #print(f"H:{self.config.port}: {e}")
+            return False
+
     
+class HexDriveType:
+    def __init__(self, pid_byte, motors=0, servos=0, name="Unknown"):
+        self.pid_byte = pid_byte
+        self.name     = name
+        self.motors   = motors
+        self.servos   = servos
+
+
 __app_export__ = HexDriveApp

--- a/hexdrive.py
+++ b/hexdrive.py
@@ -459,8 +459,9 @@ class HexDriveApp(app.App):
     def _check_port_for_hexdrive(self, port) -> int:
         #just read the part of the header which contains the PID
         try:
-            self.config.i2c.writeto(_EEPROM_ADDR, bytes([_PID_ADDR >> 8, _PID_ADDR & 0xFF]))
-            pid_bytes = self.config.i2c.readfrom(_EEPROM_ADDR, 2)
+            #self.config.i2c.writeto(_EEPROM_ADDR, bytes([_PID_ADDR >> 8, _PID_ADDR & 0xFF]))
+            #pid_bytes = self.config.i2c.readfrom(_EEPROM_ADDR, 2)
+            pid_bytes = self.config.i2c.readfrom_mem(_EEPROM_ADDR, _PID_ADDR, 2, addrsize = (8*_EEPROM_NUM_ADDRESS_BYTES))
         except OSError as e:
             # no EEPROM on this port
             print(f"H:{port}:EEPROM error: {e}")

--- a/hexdrive.py
+++ b/hexdrive.py
@@ -459,14 +459,14 @@ class HexDriveApp(app.App):
     def _check_port_for_hexdrive(self, port) -> int:
         #just read the part of the header which contains the PID
         try:
-            #self.config.i2c.writeto(_EEPROM_ADDR, bytes([_PID_ADDR >> 8, _PID_ADDR & 0xFF]))
-            #pid_bytes = self.config.i2c.readfrom(_EEPROM_ADDR, 2)
             pid_bytes = self.config.i2c.readfrom_mem(_EEPROM_ADDR, _PID_ADDR, 2, addrsize = (8*_EEPROM_NUM_ADDRESS_BYTES))
         except OSError as e:
             # no EEPROM on this port
             print(f"H:{port}:EEPROM error: {e}")
             return None
         # check the MSByte of PID for HexDrive Family
+        if len(pid_bytes) < 2:
+            return None
         if pid_bytes[1] != 0xCB:
             return None
         # check if this is a HexDrive header by scanning the _HEXDRIVE_TYPES list

--- a/utils.py
+++ b/utils.py
@@ -82,6 +82,27 @@ def draw_QRCode(ctx, qr_code, size=240, colour=(1,1,1)):
                 ctx.rectangle(x, y, pixel_size+1, pixel_size).fill()  
 
 
+def parse_version(self, version):
+    #pre_components = ["final"]
+    #build_components = ["0", "000000z"]
+    #build = ""
+    components = []
+    if "+" in version:
+        version, build = version.split("+", 1)
+        #build_components = build.split(".")
+    if "-" in version:
+        version, pre_release = version.split("-", 1)
+        #if pre_release.startswith("rc"):
+        #    # Re-write rc as c, to support a1, b1, rc1, final ordering
+        #    pre_release = pre_release[1:]
+        #pre_components = pre_release.split(".")
+    version = version.strip("v").split(".")
+    components = [int(item) if item.isdigit() else item for item in version]
+    #components.append([int(item) if item.isdigit() else item for item in pre_components])
+    #components.append([int(item) if item.isdigit() else item for item in build_components])
+    return components
+    
+
 def chain(*iterables):
     for iterable in iterables:
         yield from iterable

--- a/utils.py
+++ b/utils.py
@@ -82,7 +82,7 @@ def draw_QRCode(ctx, qr_code, size=240, colour=(1,1,1)):
                 ctx.rectangle(x, y, pixel_size+1, pixel_size).fill()  
 
 
-def parse_version(self, version):
+def parse_version(version):
     #pre_components = ["final"]
     #build_components = ["0", "000000z"]
     #build = ""


### PR DESCRIPTION
hexdrive.py was broken by changes the core badge team made to version 1.9.0 as part of making the ls gpio pins usable.
This version detects which version of the badge software it is running on and uses code selectively to be forwards/backwards compatbile.
Users will need to upgrade their HexDrive while their badge is still on v1.8.0 before upgrading to the latest badge software.

Motors now only use 1 PWM channel per motor instead of 2 - hence with a suitable App you will be able to use up to 8 motors (on 4 HexDrives) per badge.

When initialising HexDrive EEPROM you now select from 4 options:
a) 2 Motors
b) 4 Servos
c) 1 Motor and 2 Servos
d) Unknown (what all versions have been until now)
This is stored as a different PID, so that in future the HexDrive application can only take the resources required for its combination of Servos and Motors.

The BadgeBot app only offers the functions (Motor Moves and/or Servo Test) according to the hardware version fitted.

ButtonUpEvent only subscribed to when in RECEIVE_INSTR mode with focus.