### PR TITLE
ensure BLE uses the correct name once connected

### DIFF
--- a/app.py
+++ b/app.py
@@ -43,7 +43,7 @@ HEXDRIVE_APP_VERSION = 6
 HEXDRIVE2_APP_VERSION = 2
 
 SETTINGS_NAME_PREFIX = "badgebot"  # Prefix for settings keys in EEPROM
-APP_VERSION = "2.7" # BadgeBot App Version Number
+APP_VERSION = "2.8" # BadgeBot App Version Number
 
 # If you change the URL then you will need to regenerate the QR code
 # using the generate_qr_code.py script, and update the _QR_CODE constant below with the new code generated for your URL

--- a/bluetooth_mgr.py
+++ b/bluetooth_mgr.py
@@ -33,6 +33,8 @@ class RobotBLE:
         self._connections = set()
         self._write_callback = None
         self._payload = self._advertising_payload(name=name, services=[_UART_UUID])
+        # Override the internal firmware name string - This stops the phone app from falling back to "MPY ESP32" upon connection
+        self._ble.config(gap_name=name)
         self._advertise()
 
     def _irq(self, event, data):
@@ -214,13 +216,13 @@ def enable_ble_logging(ble_controller):
     if _ble_log_stream is None:
         _orig_stdout = sys.stdout
         _ble_log_stream = BleLogStream(ble_controller, _orig_stdout)
-        sys.stdout = _ble_log_stream
+        #sys.stdout = _ble_log_stream
 
 
 def disable_ble_logging():
     """Restore sys.stdout to serial-only output."""
     global _ble_log_stream, _orig_stdout
     if _ble_log_stream is not None:
-        sys.stdout = _orig_stdout
+        #sys.stdout = _orig_stdout
         _ble_log_stream = None
         _orig_stdout = None

--- a/hexpansion_mgr.py
+++ b/hexpansion_mgr.py
@@ -1038,10 +1038,10 @@ class HexpansionMgr:
             self._ports_to_initialise.add(port)
             return True
         except Exception as e:      # pylint: disable=broad-except
-            print(f"H:Error reading header on port {port}: {e}")
+            print(f"H:Unable to read header on port {port}: {e}")
             return False
         if hexpansion_header is None:
-            print(f"H:Error reading header on port {port}")
+            print(f"H:No hexpansion header read on port {port}")
             self._hexpansion_type_by_slot[port - 1] = None
             self._hexpansion_state_by_slot[port - 1] = _HEXPANSION_STATE_EMPTY
             return False

--- a/tildagon.toml
+++ b/tildagon.toml
@@ -37,4 +37,4 @@ description = "A demo tildagon app for use with Hex Drive hexpansion "
 # increased, we interpret this as a new version being released.
 #
 # Version number must be a string in major.minor format (e.g. "1.3").
-version = "2.7"
+version = "2.8"


### PR DESCRIPTION
ensure BLE uses the correct name
minor text changes to avoid use of the word "Error" when it is expected functionality.